### PR TITLE
fix: compatibility with official-like servers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ addEventListener('message', event => {
 						return JSON.parse(await response.text());
 					} catch (err) {}
 				}();
-				const official = backend.hostname === 'screeps.com' || version?.serverData?.features?.find((f: any) => f.name.toLowerCase() === 'official-like');
+				const official = backend.hostname === 'screeps.com' || version?.serverData?.features?.some((f: any) => f.name.toLowerCase() === 'official-like') ?? false;
 
 				// Look for server options payload in build information
 				for (const match of text.matchAll(/\boptions=\{/g)) {


### PR DESCRIPTION
https://github.com/screepers/steamless-client/commit/593f8a09a04077309b95e30d8249195570fdbbf7 breaks compability with xxscreeps

for `official-like` servers (like xxscreeps), `official` is an object but it should be a boolean