### PR TITLE
Build fix + Get package.nw from Steam library "forest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jszip": "3.7.1",
     "koa": "2.13.1",
     "koa-conditional-get": "3.0.0",
-    "node-fetch": "2.6.1"
+    "node-fetch": "2.6.1",
+    "steam-game-path": "github:tiennou/steam-game-path#fix/macos-support-built"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import os from 'os';
+import path from 'path';
 import { promises as fs } from 'fs';
 import { Transform } from 'stream';
 import { pathToFileURL } from 'url';
@@ -10,6 +11,7 @@ import koaConditionalGet from 'koa-conditional-get';
 import jsBeautify from 'js-beautify';
 import JSZip from 'jszip';
 import fetch from 'node-fetch';
+import { getGamePath } from "steam-game-path";
 
 // Parse program arguments
 const argv = function() {
@@ -51,18 +53,16 @@ proxy.on('error', err => console.error(err));
 
 // Locate and read `package.nw`
 const [ data, stat ] = await async function() {
-	const path = argv.package ?? function() {
-		switch (process.platform) {
-			case 'darwin': return new URL('./Library/Application Support/Steam/steamapps/common/Screeps/package.nw', `${pathToFileURL(os.homedir())}/`);
-			case 'win32': return 'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Screeps\\package.nw';
-			default: return undefined;
-		}
-	}();
-	if (!path) {
+	const pkgPath = argv.package ?? function() {
+    const steam = getGamePath(464350);
+      if (!steam || !steam.game) return undefined;
+      return path.join(steam.game.path, "package.nw");
+    }();
+	if (!pkgPath) {
 		console.log('Could not find `package.nw`. Please check `--package` argument');
 		process.exit(1);
 	}
-	return Promise.all([ fs.readFile(path), fs.stat(path) ]);
+	return Promise.all([ fs.readFile(pkgPath), fs.stat(pkgPath) ]);
 }();
 
 // Read package zip metadata

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,8 @@ addEventListener('message', event => {
 						return JSON.parse(await response.text());
 					} catch (err) {}
 				}();
-				const official = backend.hostname === 'screeps.com' || version?.serverData?.features?.some((f: any) => f.name.toLowerCase() === 'official-like') ?? false;
+				const officialLike = version?.serverData?.features?.some((f: any) => f.name.toLowerCase() === 'official-like') ?? false;
+				const official = backend.hostname === 'screeps.com' || officialLike;
 
 				// Look for server options payload in build information
 				for (const match of text.matchAll(/\boptions=\{/g)) {


### PR DESCRIPTION
This fixes not being able to locate the .nw file if the library structure is weird in any way.

Mirror of https://github.com/laverdet/screeps-steamless-client/pull/12/files

Note that I'm pointing steam-game-path to my own fork since it needs a fix for macOS *and* to be transpiled to JS. Tracking PR for that is https://github.com/osztenkurden/steam-game-path/pull/11