### PR TITLE
fix: path to index file

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,39 +14,39 @@
     <div class="cardContainer">
         <div class="card">
             <h1>Servers</h1>
-            <a href="http://localhost:8080/(http://screeps.com)/#!">
+            <a href="http://localhost:8080/(https://screeps.com)/">
                 <button>Official Server</button>
             </a>
             <div class="cardChild">
                 <h2>Community</h2>
-                <a href="http://localhost:8080/(http://server0.screepspl.us:21025)/#!">
+                <a href="http://localhost:8080/(http://server0.screepspl.us:21025)/">
                     <button>ScreepsPlus</button>
                 </a>
-                <a href="http://localhost:8080/(http://screeps.cernode.com:21025)/#!">
+                <a href="http://localhost:8080/(http://screeps.cernode.com:21025)/">
                     <button>Newbie Land</button>
                 </a>
-                <a href="http://localhost:8080/(http://jayseegames.com:21025)/#!">
+                <a href="http://localhost:8080/(http://jayseegames.com:21025)/">
                     <button>Screeps Sandbox</button>
                 </a>
-                <a href="http://localhost:8080/(http://screeps.ch3.network:21025)/#!">
+                <a href="http://localhost:8080/(http://screeps.ch3.network:21025)/">
                     <button>Channel3</button>
                 </a>
-                <a href="http://localhost:8080/(http://screeps.gohorse.dev:21025)/#!">
+                <a href="http://localhost:8080/(http://screeps.gohorse.dev:21025)/">
                     <button>Go Horse Brazilian</button>
                 </a>
             </div>
             <div class="cardChild">
                 <h2>Community Tournaments</h2>
-                <a href="http://localhost:8080/(http://botarena.screepspl.us:21025)/#!">
+                <a href="http://localhost:8080/(http://botarena.screepspl.us:21025)/">
                     <button>Botarena</button>
                 </a>
-                <a href="http://localhost:8080/(http://swc.screepspl.us:21025)/#!">
+                <a href="http://localhost:8080/(http://swc.screepspl.us:21025)/">
                     <button>SWC</button>
                 </a>
             </div>
             <div class="cardChild">
                 <h2>Private</h2>
-                <a href="http://localhost:8080/(http://localhost:21025)/#!">
+                <a href="http://localhost:8080/(http://localhost:21025)/">
                     <button>Local Server</button>
                 </a>
             </div>


### PR DESCRIPTION
- Uses `path.join(__dirname, '..', 'public')` to build an absolute path to the public dir.
- Fixes the link to official server by adding `https`. 
- Removed `#!` from the links so the pages will load faster.

![Screenshot from 2024-06-08 21-49-16](https://github.com/screepers/steamless-client/assets/10291543/942da650-7987-43b3-8249-c0bbe7b4e0af)
