### PR TITLE
fix: release script and game path search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "screepers-steamless-client",
-    "version": "1.8.0",
+    "version": "1.10.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "screepers-steamless-client",
-            "version": "1.8.0",
+            "version": "1.10.3",
             "license": "ISC",
             "dependencies": {
                 "@ladjs/koa-views": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,6 @@
     },
     "dependencies": {
         "@ladjs/koa-views": "^9.0.0",
-        "@semantic-release/commit-analyzer": "^13.0.0",
-        "@semantic-release/github": "^10.0.6",
-        "@semantic-release/npm": "^12.0.1",
-        "@semantic-release/release-notes-generator": "^14.0.1",
         "argparse": "2.0.1",
         "chalk": "^5.3.0",
         "ejs": "^3.1.10",
@@ -61,7 +57,6 @@
         "koa": "2.15.3",
         "koa-conditional-get": "3.0.0",
         "node-fetch": "^3.3.2",
-        "semantic-release": "^24.0.0",
         "winreg": "^1.2.5"
     }
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Get the current version from package.json
+currentVersion=$(node -p "require('./package.json').version")
+
+# Run semantic-release
+npx semantic-release
+
+# Get the new version from package.json
+newVersion=$(node -p "require('./package.json').version")
+
+# Revert package.json to its state in the Git repository
+git checkout HEAD -- package.json
+
+# If the version has changed, update the version in package.json
+if [[ "$currentVersion" != "$newVersion" ]]; then
+    git config --local user.email "action@github.com"
+    git config --local user.name "GitHub Action"
+    npm version --no-git-tag-version $newVersion
+    git add package.json
+    git commit -m "chore: release $newVersion [skip ci]"
+    git push
+fi

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -67,7 +67,7 @@ const exitOnPackageError = () => {
 // Locate and read `package.nw`
 const readPackageData = async () => {
     const pkgPath = argv.package ?? (await getScreepsPath());
-    if (!pkgPath) exitOnPackageError();
+    if (!pkgPath || !existsSync(pkgPath)) exitOnPackageError();
     console.log('📦', chalk.dim('Package >'), chalk.gray(pkgPath));
     return Promise.all([fs.readFile(pkgPath), fs.stat(pkgPath)]).catch(exitOnPackageError);
 };


### PR DESCRIPTION
* Revised release action to only commit the package version changes post-release (old attempt also committed semantic-release dependencies that are unnecessary)

* Improve game path search on Windows fallback (get system drive letter from env) and WSL (check all mounted drives)