### PR TITLE
fix: Docker localhost urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+RUN git clone https://github.com/admon84/screeps-steamless-client.git .
+
+RUN git checkout fix/docker
+
+RUN npm install
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM node:20
-
 WORKDIR /app
 
-RUN git clone https://github.com/admon84/screeps-steamless-client.git .
+# Clone the repo
+RUN git clone https://github.com/admon84/screeps-steamless-client.git /tmp/repo
 
+# Copy all files from the repo to the app directory
+RUN mv /tmp/repo/* /tmp/repo/.* /app/ || true
+RUN rm -rf /tmp/repo
+
+# Checkout the fix/docker branch
+RUN git fetch
 RUN git checkout fix/docker
 
+# Install the dependencies
 RUN npm install
 
-CMD ["npm", "start"]
+CMD ["npm", "start", "--", "--package", "/screeps.nw"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,6 @@
 FROM node:20
+RUN rm -rf /app
 WORKDIR /app
-
-# Clone the repo
-RUN git clone https://github.com/admon84/screeps-steamless-client.git /tmp/repo
-
-# Copy all files from the repo to the app directory
-RUN mv /tmp/repo/* /tmp/repo/.* /app/ || true
-RUN rm -rf /tmp/repo
-
-# Checkout the fix/docker branch
-RUN git fetch
-RUN git checkout fix/docker
-
-# Install the dependencies
+RUN git clone --branch main --single-branch https://github.com/screepers/steamless-client.git /app
 RUN npm install
-
-CMD ["npm", "start", "--", "--package", "/screeps.nw"]
+CMD ["npm", "start", "--", "--package", "/screeps.nw", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Screepers Steamless Client is a web proxy for the [Screeps World](https://st
 
 ### Run with NPX
 
-Install the latest version in a temporary location and run the client:
+Run the latest version with npx without installing:
 
 ```sh
 npx screepers-steamless-client
@@ -30,9 +30,12 @@ screepers-steamless-client
 
 ### Run with Docker Compose
 
-Use Docker Compose to run the client. Download our [`compose.yaml`](compose.yaml) file and place it in an empty folder. Alternatively, you can incorporate the `client` service into an existing Docker Compose configuration.
+Use Docker Compose to run the client.
+- Download the [`compose.yaml`](compose.yaml) file and place it in an empty folder.
+- Alternatively, you can incorporate the `client` entry from [`compose.yaml`](compose.yaml) into an existing docker compose config (for example: combine with a screeps server launcher).
 
-Create a `.env` file with the following content in the same folder as the compose.yaml. Replace the path with the actual path to your Screeps `package.nw` file:
+Set up the `SCREEPS_NW_PATH` environment variable.
+- Create a `.env` file with the following content in the same folder as the compose.yaml. Replace the path with the actual path to your Screeps `package.nw` file:
 
 ```bash
 SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"

--- a/README.md
+++ b/README.md
@@ -11,17 +11,52 @@ The Screepers Steamless Client is a web proxy for the [Screeps World](https://st
 
 ## Installation
 
-Option 1. Temporarily install and run the latest client app:
+### Run with NPX
+
+Install the latest version in a temporary location and run the client:
 
 ```sh
 npx screepers-steamless-client
 ```
 
-Option 2. Install globally and then run the client app:
+### Install Globally with NPM
+
+Install the latest version globally with npm and run the client:
 
 ```sh
 npm install -g screepers-steamless-client
 screepers-steamless-client
+```
+
+### Run with Docker Compose
+
+Use Docker Compose to run the client. Create a `compose.yaml` file in an empty folder or update an existing one by adding the `client` entry under `services`.
+
+```yaml
+services:
+  client:
+    image: node:20
+    command: >
+      npx screepers-steamless-client
+      --package /screeps.nw
+      --host 0.0.0.0
+    volumes:
+      - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
+    ports:
+      - 8080:8080
+    restart: unless-stopped
+```
+
+Create a `.env` file with the following content. Replace the path with the actual path to your Screeps `package.nw` file.
+
+```bash
+SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"
+```
+
+Run the Docker container:
+
+```bash
+docker compose up
 ```
 
 ## Usage
@@ -42,6 +77,8 @@ Steam OpenId support is required on your local server. Enable it with [screepsmo
 
 All of the command line arguments are optional.
 
+- `-h` , `--help` &mdash; Display the help message.
+- `-v` , `--version` &mdash; Display the version number.
 - `--package` &mdash; Path to the Screeps package.nw file. Use this if the path isn't automatically detected.
 - `--host` &mdash; Changes the host address. (default: localhost)
 - `--port` &mdash; Changes the port. (default: 8080)
@@ -50,80 +87,50 @@ All of the command line arguments are optional.
 - `--server_list` &mdash; Path to a custom server list json config file.
 - `--beautify` &mdash; Formats .js files loaded in the client for debugging.
 - `--debug` &mdash; Display verbose errors for development.
-- `-v` , `--version` &mdash; Display the version number.
-- `-h` , `--help` &mdash; Display the help message.
 
-## Argument Examples
+## Examples
 
-### Screeps package.nw
+### `--package`
 
-If the Screeps package.nw is not automatically detected, you will need to set the path like this:
+If the Screeps package.nw is not automatically detected, you can provide the path to the Screeps package.nw file.
 
 ```sh
-npx screepers-steamless-client --package ~/Screeps/package.nw
+npx screepers-steamless-client --package ~/screeps/package.nw
 ```
 
-### Backend proxy
+### `--backend`
 
-Proxy a server directly (disables the server list page).
+Proxy a specific server and disable the server list page.
 
 ```sh
 npx screepers-steamless-client --backend http://localhost:21025
 ```
 
-### Docker compose
+### `--internal_backend`
 
-Example usage with Jomik's [screeps-server](https://github.com/Jomik/screeps-server). You can add this `client` service into your existing docker-compose.yml:
+Specify the internal backend for container environments when using the `--backend` option.
 
-```yaml
-# docker-compose.yml
-version: '3'
-services:
-  # ... existing services ...
-
-  client:
-    image: node:20
-    command: >
-      sh -c 'npx screepers-steamless-client
-      --package /screeps.nw
-      --host 0.0.0.0
-      --internal_backend http://screeps:21025
-      --backend http://localhost:21025'
-    volumes:
-      - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
-    ports:
-      - 8080:8080
-    restart: unless-stopped
+```sh
+npx screepers-steamless-client --backend http://localhost:21025 --internal_backend http://screeps:21025
 ```
 
-Set up the env variable `SCREEPS_NW_PATH` with the correct path to your Screeps package.nw (for example on macOS):
+### `--server_list`
 
-```bash
-# .env
-SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"
-```
+Customize your server list by copying the [server_list.json](settings/server_list.json) file and making your changes.
 
-### Custom server list
-
-Set the path to a custom server list json config file.
+Run the client with your custom server list:
 
 ```sh
 npx screepers-steamless-client --server_list ./custom_server_list.json
 ```
 
-The custom server list json file should follow the same format as [server_list.json](settings/server_list.json). Each object in the json file should include a type, name, and url:
-* `type` &mdash; This is used to organize servers into sections.
-* `name` &mdash; This is the name of the server.
-* `url` &mdash; This is used to create a link to the server.
-* `subdomain` &mdash; This prefixes localhost urls for multi server support.
-
 ## Development Scripts
 
-- `npm start` &mdash; Builds and starts the client app.
-- `npm run build` &mdash; Builds the client app to dist.
-- `npm run dev` &mdash; Builds and watches for changes (hot reloading).
-- `npm run format` &mdash; Formats the src using Prettier.
-- `npm run lint` &mdash; Lints the src using ESLint.
+- `npm start` &mdash; Build and start the client app.
+- `npm run build` &mdash; Build the client app to dist.
+- `npm run dev` &mdash; Build and watch for changes (hot reload).
+- `npm run format` &mdash; Format the src using Prettier.
+- `npm run lint` &mdash; Lint the src using ESLint.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -30,24 +30,9 @@ screepers-steamless-client
 
 ### Run with Docker Compose
 
-Use Docker Compose to run the client. Create a `compose.yaml` file in an empty folder or update an existing one by adding the `client` entry under `services`.
+Use Docker Compose to run the client. Download our [`compose.yaml`](compose.yaml) file and place it in an empty folder. Alternatively, you can incorporate the `client` service into an existing Docker Compose configuration.
 
-```yaml
-services:
-  client:
-    image: node:20
-    command: >
-      npx screepers-steamless-client
-      --package /screeps.nw
-      --host 0.0.0.0
-    volumes:
-      - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
-    ports:
-      - 8080:8080
-    restart: unless-stopped
-```
-
-Create a `.env` file with the following content. Replace the path with the actual path to your Screeps `package.nw` file.
+Create a `.env` file with the following content in the same folder as the compose.yaml. Replace the path with the actual path to your Screeps `package.nw` file:
 
 ```bash
 SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,11 @@
 services:
   client:
     image: node:20
-    command: >
-      npx screepers-steamless-client
-      --package /screeps.nw
-      --host 0.0.0.0
+    # command: >
+    #   npx screepers-steamless-client
+    #   --package /screeps.nw
+    #   --host 0.0.0.0
+    build: .
     volumes:
       - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  client:
+    image: node:20
+    command: >
+      npx screepers-steamless-client
+      --package /screeps.nw
+      --host 0.0.0.0
+    volumes:
+      - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
+    ports:
+      - 8080:8080
+    restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,12 @@
 services:
   client:
     image: node:20
-    # command: >
-    #   npx screepers-steamless-client
-    #   --package /screeps.nw
-    #   --host 0.0.0.0
-    build: .
+    command: >
+      npx screepers-steamless-client
+      --package /screeps.nw
+      --host 0.0.0.0
     volumes:
-      - ${SCREEPS_NW_PATH:?"Missing screeps nw file"}:/screeps.nw
+      - ${SCREEPS_NW_PATH:?"SCREEPS_NW_PATH not set"}:/screeps.nw
     ports:
       - 8080:8080
     restart: unless-stopped

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -90,6 +90,8 @@ const argv = (() => {
     return parser.parse_args();
 })();
 
+const hostAddress = argv.host === '0.0.0.0' ? DEFAULT_HOST : argv.host;
+
 // Log welcome message
 console.log('🧩', chalk.yellowBright(`Screepers Steamless Client v${version}`));
 
@@ -144,7 +146,7 @@ koa.use(async (context, next) => {
     if (argv.backend) return next(); // Skip if backend is specified
 
     if (['/', 'index.html'].includes(context.path)) {
-        const serverList = await getServerListConfig(host, port, argv.server_list);
+        const serverList = await getServerListConfig(hostAddress, port, argv.server_list);
         if (serverList.length) {
             await context.render(indexFile, { serverList });
             return;
@@ -195,7 +197,7 @@ koa.use(async (context, next) => {
     context.lastModified = lastModified;
     if (context.fresh) return;
 
-    const clientHost = context.header.host || `${host}:${port}`;
+    const clientHost = context.header.host || `${hostAddress}:${port}`;
 
     const client = new Client({
         host: clientHost,

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -130,7 +130,9 @@ const koa = new Koa();
 const { host, port } = argv;
 const server = koa.listen(port, host);
 server.on('error', (err) => handleServerError(err, argv.debug));
-server.on('listening', () => console.log('🌐', chalk.dim('Ready', arrow), chalk.white(`http://${host}:${port}/`)));
+server.on('listening', () =>
+    console.log('🌐', chalk.dim('Ready', arrow), chalk.white(`http://${hostAddress}:${port}/`)),
+);
 
 // Get system path for public files dir
 const indexFile = 'index.ejs';


### PR DESCRIPTION
### Docker fix

Fixes urls when running with `--host 0.0.0.0` for a docker container. Internally overwrites the host to use `localhost` so the client can be accessed in the browser on localhost as expected.
