### PR TITLE
fix: proxy error handler

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -10,7 +10,6 @@ import path from 'path';
 import { ArgumentParser } from 'argparse';
 import { createReadStream, existsSync, promises as fs } from 'fs';
 import { fileURLToPath, URL } from 'url';
-import { ServerResponse } from 'http';
 import { Transform } from 'stream';
 import { Client, Route } from './utils/client';
 import { getScreepsPath } from './utils/gamePath';
@@ -92,7 +91,7 @@ console.log('🧩', chalk.yellowBright(`Screepers Steamless Client v${version}`)
 
 // Create proxy
 const proxy = httpProxy.createProxyServer({ changeOrigin: true });
-proxy.on('error', (err, _req, res) => handleProxyError(err, res as ServerResponse, argv.debug));
+proxy.on('error', (err, req, res) => handleProxyError(err, res, argv.debug));
 
 const exitOnPackageError = () => {
     if (argv.package) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,7 +36,7 @@ export function logError(...args: unknown[]) {
 export function handleProxyError(err: ServerError, res: ServerResponse | Socket, debug?: boolean) {
     handleServerError(err, debug);
 
-    if (res instanceof ServerResponse && err.code === 'ECONNREFUSED') {
+    if (err.code === 'ECONNREFUSED' && res instanceof ServerResponse) {
         // Return a plain/text response so the client will stop loading.
         res.writeHead(500, { 'Content-Type': 'plain/text' });
         res.end(String(err));

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,11 +36,11 @@ export function logError(...args: unknown[]) {
 export function handleProxyError(err: ServerError, res: ServerResponse | Socket, debug?: boolean) {
     handleServerError(err, debug);
 
-    if (res instanceof ServerResponse) {
+    if (res instanceof ServerResponse && err.code === 'ECONNREFUSED') {
         // Return a plain/text response so the client will stop loading.
         res.writeHead(500, { 'Content-Type': 'plain/text' });
+        res.end(String(err));
     }
-    res.end(String(err));
 }
 
 /**

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { ServerResponse } from 'http';
-import { Socket } from 'net';
+import type { Socket } from 'net';
 import { ServerError } from './types';
 
 const errorCodes: Record<PropertyKey, string> = {


### PR DESCRIPTION
The proxy error handler extends the example from [http-proxy](https://github.com/http-party/node-http-proxy?tab=readme-ov-file#listening-for-proxy-events).

I updated this error handler to only throw the 500 error for `ECONNREFUSED` so that it stops the loading animation when trying to connect to an offline server, but won't affect other types of errors.

Writing `String(err)` as the response creates a readable response message:

![](https://github.com/user-attachments/assets/69125d5a-432e-459a-9e66-491a87c11daa)
