### PR TITLE
build: Improve Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+/node_modules
+/dist
+/vendor/*.nw
+.env
+
+/.git
+/.github
+/.vscode
+/docs
+/scripts
+/.dockerignore
+/.gitignore
+/compose.yaml
+/Dockerfile
+/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
+/vendor/*.nw
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 FROM node:20
-RUN rm -rf /app
-WORKDIR /app
-RUN git clone --branch main --single-branch https://github.com/screepers/steamless-client.git /app
-RUN npm install
-CMD ["npm", "start", "--", "--package", "/screeps.nw", "--host", "0.0.0.0"]
+
+WORKDIR /srv/screeps
+
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm clean-install --ignore-scripts
+
+COPY . .
+
+ENV PATH="${PATH}:/srv/screeps/node_modules/bin"
+RUN npm run --ignore-scripts build
+
+ENTRYPOINT ["npm", "--ignore-scripts"]
+# NOTE: This command will not work out of the box.
+# screeps.nw is not included in the image, as it is copyrighted.
+# See README.md and compose.yaml for more information.
+CMD ["start", "--", "--package", "/screeps.nw", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The Screepers Steamless Client is a web proxy for the [Screeps World](https://st
 
 ## Requirements
 
-- Node.js v20+
-- Screeps World (installed using Steam)
+- Node.js v20+ or Docker Compose v3+
+- Screeps World installed via Steam (not necessarily on the same system on which you will deploy the proxy)
 
 ## Installation
 
@@ -28,31 +28,54 @@ npm install -g screepers-steamless-client
 screepers-steamless-client
 ```
 
-### Run with Docker Compose
+### Install or Run with Docker Compose
 
 Use Docker Compose to run the client.
-- Download the [`compose.yaml`](compose.yaml) file and place it in an empty folder.
-- Alternatively, you can add the `client` entry from [`compose.yaml`](compose.yaml) to an existing Docker Compose configuration (e.g., combine it with a Screeps server launcher). If you do this, make sure to use the `--internal_backend` argument in the command to reference the Screeps server container address, like this:
 
+1. Clone this repository
+
+2. Locate the Screeps `package.nw` file from the Steam installation of Screeps. If you are unsure of where to find it, you can right click the game from your Steam library and select the "Browse local files" option.
+
+3. Create a `.env` file in the repo root directory and set `SCREEPS_NW_PATH` to the path of `package.nw`:
+
+    1. If you have Screeps installed on your local machine via Steam, you can reference it directly. For example, on macOS:
+        ```bash
+        SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"
+        ```
+
+    2. If Steam and/or Screeps is not installed locally, you can copy `package.nw` from a remote system and place it in the `vendor` subdirectory:
+        ```sh
+        SCREEPS_NW_PATH="./vendor/package.nw"
+        ```
+
+4. If you want to allow remote connections, add the following line to `.env`:
+    ```sh
+    SCREEPS_PROXY_HOST="0.0.0.0"
+    ```
+
+5. Run `docker compose up`
+
+Alternatively, you can run the container without cloning the repo by using the NPX run approach from a container. This makes it easier to integrate with existing Docker Compose configurations (ex: alongside a Screeps server launcher).
+
+If your deployment includes a Screeps server, make sure to use the `--internal_backend` argument in the command to reference the Screeps server container address.
+
+Example:
 ```yaml
+services:
+  client:
+    image: "node:20"
+    volumes:
+      - ${SCREEPS_NW_PATH:?"SCREEPS_NW_PATH not set"}:/screeps.nw
     command: >
       npx screepers-steamless-client
       --package /screeps.nw
       --host 0.0.0.0
       --internal_backend http://screeps:21025
-```
-
-Set up the `SCREEPS_NW_PATH` environment variable.
-- Create a `.env` file with the following content in the same folder as the compose.yaml. Replace the path with the actual path to your Screeps `package.nw` file:
-
-```bash
-SCREEPS_NW_PATH="~/Library/Application Support/Steam/steamapps/common/Screeps/package.nw"
-```
-
-Run the Docker container:
-
-```bash
-docker compose up
+    ports:
+      - "${SCREEPS_PROXY_HOST:-127.0.0.1}:8080:8080/tcp"
+    depends_on:
+      - screeps
+    restart: unless-stopped
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ The Screepers Steamless Client is a web proxy for the [Screeps World](https://st
 ## Requirements
 
 - Node.js v20+ or Docker Compose v3+
-- Screeps World installed via Steam (not necessarily on the same system on which you will deploy the proxy)
+- Screeps World purchased and installed via Steam
+
+Steam and the game do not necessarily need to be installed on the same system on which you will deploy the proxy.
+**However**, the game should be legally purchased by you and installed on a system you own.
+Not only does this support the developers, but it allows you to keep your proxy up-to-date,
+as the client receives regular updates automatically via Steam. Copying the client binary
+from another system will require you to repeat that process each time the client is updated.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ services:
     image: "node:20"
     volumes:
       - ${SCREEPS_NW_PATH:?"SCREEPS_NW_PATH not set"}:/screeps.nw
+      # Defines a volume for the NPM cache to speed up startup
+      # when the container is recreated
+      - client-npm-cache:/root/.npm
     command: >
       npx screepers-steamless-client
       --package /screeps.nw
@@ -82,6 +85,11 @@ services:
     depends_on:
       - screeps
     restart: unless-stopped
+
+  # Additional services defined here...
+
+volumes:
+  client-npm-cache:
 ```
 
 ## Usage

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,15 @@
+name: "screeps-client"
+
 services:
   client:
-    image: node:20
-    command: >
-      npx screepers-steamless-client
-      --package /screeps.nw
-      --host 0.0.0.0
+    build: .
     volumes:
       - ${SCREEPS_NW_PATH:?"SCREEPS_NW_PATH not set"}:/screeps.nw
+    command:
+      - "start"
+      - "--"
+      - "--package=/screeps.nw"
+      - "--host=0.0.0.0"
     ports:
-      - 8080:8080
+      - "${SCREEPS_PROXY_HOST:-127.0.0.1}:8080:8080/tcp"
     restart: unless-stopped


### PR DESCRIPTION
This change aims to make it easier to build/deploy the proxy via Docker Compose from a clone of this repo.

A .dockerignore file was created to reduce image size and improve the layer cache hit rate.

This change also restricts external access to the web proxy port to the host machine by default. To revert to the old behavior, add the following environment variable:
```
SCREEPS_PROXY_HOST=0.0.0.0
```

I also updated the docs with instructions on how to deploy on a machine that doesn't have Steam installed.
`vendor/*.nw` was added to .gitignore/.dockerignore to prevent anybody using this approach from accidentally distributing the Screeps client package.