### PR TITLE
fix: make generated script executable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "tsconfig.json",
+    "project": "tsconfig.eslint.json",
     "sourceType": "module"
   },
   "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "prettier": "^3.3.2",
                 "rimraf": "^5.0.7",
                 "rollup": "^4.18.0",
+                "rollup-plugin-shebang-bin": "^0.1.0",
                 "typescript": "5.5.2"
             }
         },
@@ -230,6 +231,13 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@ladjs/consolidate": {
             "version": "1.0.3",
@@ -573,14 +581,15 @@
             }
         },
         "node_modules/@rollup/pluginutils": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
-            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+            "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^2.0.2",
-                "picomatch": "^2.3.1"
+                "picomatch": "^4.0.2"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -592,6 +601,19 @@
                 "rollup": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3069,6 +3091,16 @@
                 "node": "14 || >=16.14"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -3670,6 +3702,23 @@
                 "@rollup/rollup-win32-ia32-msvc": "4.18.0",
                 "@rollup/rollup-win32-x64-msvc": "4.18.0",
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-shebang-bin": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-shebang-bin/-/rollup-plugin-shebang-bin-0.1.0.tgz",
+            "integrity": "sha512-BctqAmLbtDXq5yePelTU/g0Jjz7pKzxluGzUB4DlI91BhzKbFb5WrgRyOIRjMqAouWUsdMMqs4vPKjRTlNVcZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.3",
+                "magic-string": "^0.30.15"
+            },
+            "engines": {
+                "node": ">= 14.18"
+            },
+            "peerDependencies": {
+                "rollup": "^2 || ^3 || ^4"
             }
         },
         "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "prettier": "^3.3.2",
         "rimraf": "^5.0.7",
         "rollup": "^4.18.0",
+        "rollup-plugin-shebang-bin": "^0.1.0",
         "typescript": "5.5.2"
     },
     "dependencies": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,8 @@
 import typescript from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
+import shebang from 'rollup-plugin-shebang-bin'
 
+/** @type {import('rollup').RollupOptions} */
 const baseConfig = {
   output: {
     dir: 'dist',
@@ -8,7 +10,8 @@ const baseConfig = {
   },
   plugins: [
     nodeResolve(),
-    typescript({ tsconfig: './tsconfig.json' })
+    typescript({ tsconfig: './tsconfig.json' }),
+    shebang({ include: "src/clientApp.ts" }),
   ],
   external: id => /node_modules/.test(id)
 };

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import views from '@ladjs/koa-views';
 import { ArgumentParser } from 'argparse';
 import chalk from 'chalk';

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "rollup.config.mjs"
+  ]
+}


### PR DESCRIPTION
This ensures the `dist/clientApp.js` script is properly marked as +x, which fixes an issue with `npx` failing to execute it.