### PR TITLE
fix: problems with hardcoded http URLs

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -327,7 +327,8 @@ koa.use(async (context, next) => {
                                     // Inject host, port, and official
                                     src = `${src.substring(0, i)},
                                         host: ${JSON.stringify(backend.hostname)},
-                                        port: ${backend.port || '80'},
+                                        protocol: "${backend.protocol}",
+                                        port: ${backend.port || (backend.protocol === 'https:' ? '443' : '80')},
                                         official: ${isOfficialLike},
                                     } ${src.substring(i + 1)}`;
                                 }
@@ -348,7 +349,10 @@ koa.use(async (context, next) => {
                 }
 
                 // Replace URLs with local client paths
-                src = src.replace(/https:\/\/screeps.com\/a\//g, client.getURL(Route.ROOT));
+                src = src.replace(/https:\/\/screeps\.com\/a\//g, client.getURL(Route.ROOT));
+
+                // Fix the hardcoded protocol in URLs
+                src = src.replace(/"http:\/\/"\+([^\.]+)\.options\.host/g, '$1.options.protocol+"//"+$1.options.host');
             }
             return argv.beautify ? jsBeautify(src) : src;
         } else if (urlPath === 'components/profile/profile.html') {


### PR DESCRIPTION
This adds the actual backend protocol to the options object we hack in, and replaces any occurrences of "http://" + host the client likes to do with the correct protocol.

Fixes loading map tiles through http even though the backend is server over https (making it rely on having an accessible http version, which might not exist).

To reproduce, open http://pandascreeps.localhost:8080/(https://server.pandascreeps.com/)/#!/map/shard0?pos=2.46,3.046 and http://pandascreeps.localhost:8080/(https://server.pandascreeps.com/)/#!/profile/Gadjung. Make sure you don't get redirected to the http version when logging in, I had that happen and it's confusing.

Before the patch, the first one can be observed loading map tiles through http://server.pandascreeps.com:21025/assets/map/W0S1.png?bust=1739218060553, which happens to work but isn't technically correct.

Note that I've checked the map and profile page, but that's about it. 🤞 I'm not catching something else in the middle of that batch-rewrite.