### PR TITLE
fix: Stop the client switching to spawn mode by default when unspawned

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -352,6 +352,12 @@ koa.use(async (context, next) => {
 
                 // Fix the hardcoded protocol in URLs
                 src = src.replace(/"http:\/\/"\+([^\.]+)\.options\.host/g, '$1.options.protocol+"//"+$1.options.host');
+
+                // Remove the default-to-place-spawn behavior when you're not spawned in
+                src = src.replace(
+                    'h.get("user/world-status").then(function(t){"empty"==t.status&&(P.selectedAction.action="spawn",',
+                    'h.get("user/world-status").then(function(t){"empty"==t.status&&(',
+                );
             }
             return argv.beautify ? jsBeautify(src) : src;
         } else if (urlPath === 'components/profile/profile.html') {


### PR DESCRIPTION
This makes the client stay in view mode until you actually decide the room is worth and you want to spawn in.

Mostly because it's tiresome to always have to switch back when you're simply looking around.