### PR TITLE
feat: Expose portal stability data in the inspector

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -440,6 +440,32 @@ koa.use(async (context, next) => {
             );
 
             return src;
+        } else if (urlPath === 'components/game/room/properties/portal.html') {
+            let src = await file.async('text');
+
+            // Fix the portal stability info showing only if it's an intershard portal
+            // Additionally, expose the stable date in the inspector
+            const unstableDateInfo =
+                "<div ng-if='Room.selectedObject.unstableDate'>\n" +
+                '<label>Stable until:</label>\n' +
+                "<span id='screepers-stable-date' data-unstabledate='{{Room.selectedObject.unstableDate}}'/>\n" +
+                '<script>\n' +
+                'setTimeout(() => {\n' +
+                "\tconst dateField = document.getElementById('screepers-stable-date');\n" +
+                '\tif (!dateField) return;\n' +
+                "\tconst date = dateField.getAttribute('data-unstabledate');\n" +
+                '\tconst unstableStamp = parseInt(date, 10)\n' +
+                '\tdateField.innerText = new Date(unstableStamp).toLocaleString()\n' +
+                '}, 20);\n' +
+                '</script>\n' +
+                '</div>\n';
+            src = applyPatch(
+                src,
+                "<div ng-if='Room.selectedObject.destination &amp;&amp; Room.selectedObject.destination.shard'>",
+                unstableDateInfo + "<div ng:if='!Room.selectedObject.unstableDate'>",
+            );
+            src = applyPatch(src, 'portal is stable yet', 'portal is stable');
+            return src;
         } else {
             // JSZip doesn't implement their read stream correctly and it causes EPIPE crashes. Pass it
             // through a no-op transform stream first to iron that out.


### PR DESCRIPTION
Fixes an issue where the inspector only shows stability/decay info if the portal is an intershard portal. Given those are unlikely to happen on a private server, the UI there becomes really limited. Hence, remove the check for what sort of destination the portal has, and add the missing `unstableDate` viewing to the inspector:

<img width="195" alt="Capture d’écran 2025-03-06 à 23 26 46" src="https://github.com/user-attachments/assets/b12f49fa-39f5-4ce1-9d64-810dc3b4c8e4" />

Decaying portals now show this:

<img width="169" alt="Capture d’écran 2025-03-06 à 23 27 25" src="https://github.com/user-attachments/assets/f04edb2f-f245-4643-9c15-89bbe063092c" />

Or this if they're permanent:

<img width="190" alt="Capture d’écran 2025-03-06 à 23 28 05" src="https://github.com/user-attachments/assets/01f4f6fb-67e2-4654-98bf-be364dc56f30" />

Test cases were:
- unstable portal in [shard2/W45N15](http://mmo.localhost:8080/(https://screeps.com)/#!/room/shard2/W45N15)
- stable portal in [shard2/W40N20](http://mmo.localhost:8080/(https://screeps.com)/#!/room/shard2/W40N20)
- a decaying portal in a pserver

I had to jump through hoops to make the unstable date work properly, since I'm hacking from outside the whole Angular app; that's why there's a sudden `<script>` tag with a timeout; so that Angular can actually update the DOM as requested, and then the script can grab it to do the date formatting.