### PR TITLE
feat: Add CLI flags for external client access when hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ All of the command line arguments are optional.
 - `--package` &mdash; Path to the Screeps package.nw file. Use this if the path isn't automatically detected.
 - `--host` &mdash; Changes the host address. (default: localhost)
 - `--port` &mdash; Changes the port. (default: 8080)
+- `--public_hostname` &mdash; The hostname that clients can use to access the client; useful when running in a container. (default: `--host` value)
+- `--public_port` &mdash; The port that clients can use to access the client; useful when running in a container. (default: `--port` value)
+- `--public_tls` &mdash; Whether the public address should use TLS; useful when running in a container. (default: false)
+- `--use_subdomains` &mdash; Whether the server links should use subdomains off of the public address. (default: false)
 - `--internal_backend` &mdash; Set the internal backend url when running the Screeps server in a local container. This will convert requests to a localhost backend to use the container name where the Screeps server is running.
 - `--server_list` &mdash; Path to a custom server list json config file.
 - `--beautify` &mdash; Formats .js files loaded in the client for debugging.
@@ -147,6 +151,14 @@ Run the client with your custom server list:
 
 ```sh
 npx screepers-steamless-client --server_list ./custom_server_list.json
+```
+
+### Behind a reverse proxy
+
+You can run the steamless client behind a reverse proxy (such as in a container) by specifying the public-facing hostname and port. This will ensure that the generated links use the public-facing address instead of the internal bind address.
+
+```sh
+npx screepers-steamless-client --public_hostname screeps-client.example.com --public_port 443 --public_tls --use_subdomains
 ```
 
 ## Development Scripts

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -75,7 +75,7 @@ export function generateScriptTag(func: Function, args: { [key: string]: unknown
 /**
  * Utility to get the server list configuration.
  */
-export async function getServerListConfig(dirname: string, host: string, port: number, serverListPath?: string) {
+export async function getServerListConfig(dirname: string, protocol: string, host: string, port: number, useSubdomains: boolean, serverListPath?: string) {
     if (!serverListPath) {
         const serverListFile = 'server_list.json';
         serverListPath = path.join(dirname, `../settings/${serverListFile}`);
@@ -90,12 +90,15 @@ export async function getServerListConfig(dirname: string, host: string, port: n
         const serversOfType = serverConfig
             .filter((server) => server.type === type)
             .map((server) => {
-                const subdomain = host === 'localhost' && server.subdomain ? `${server.subdomain}.` : '';
+                const subdomain = useSubdomains && server.subdomain ? `${server.subdomain}.` : '';
                 const { origin, pathname } = new URL(server.url);
                 const urlpath = pathname.endsWith('/') ? pathname : `${pathname}/`;
 
-                const url = `http://${subdomain}${host}:${port}/(${origin})${urlpath}`;
-                const api = `http://${host}:${port}/(${origin})${urlpath}api/version`;
+                const protocolPort = protocol == 'https' ? 443 : 80;
+                const hostport = port == protocolPort ? host : `${host}:${port}`;
+
+                const url = `${protocol}://${subdomain}${hostport}/(${origin})${urlpath}`;
+                const api = `${protocol}://${hostport}/(${origin})${urlpath}api/version`;
                 return { ...server, url, api };
             });
 


### PR DESCRIPTION
This PR updates the client app to allow for specifying the external address, port, and protocol of the client, for use with the server listings.

This allows the client to be used from within a container, or from behind a reverse proxy, where the `host` and `port` parameters used for local binding/listening do not match the hostname and port used to access the client.

Behavior of the client should match the existing behavior when the new CLI arguments are not used.