### PR TITLE
fix: Adjust internal URLs to match public protocol

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -238,6 +238,7 @@ koa.use(async (context, next) => {
 
     const client = new Client({
         host: clientHost,
+        protocol: publicProtocol,
         prefix,
         backend: info.backend,
     });
@@ -253,7 +254,7 @@ koa.use(async (context, next) => {
                     ? `${client.getURL(Route.ROOT)}season/`
                     : client.getURL(Route.ROOT, { prefix: false });
             const ptrLink = isOfficial && !prefix ? `${client.getURL(Route.ROOT)}ptr/` : undefined;
-            const changeServerLink = `http://${trimLocalSubdomain(clientHost)}/`;
+            const changeServerLink = `${publicProtocol}://${trimLocalSubdomain(clientHost)}/`;
 
             // Inject startup script
             const header = '<title>Screeps</title>';

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -20,11 +20,13 @@ export enum Route {
  */
 export class Client {
     private host: string;
+    private protocol: string;
     private basePath: string;
     private prefix: string;
 
-    constructor({ host, prefix, backend }: { host: string; backend: string; prefix?: string }) {
+    constructor({ host, protocol, prefix, backend }: { host: string; protocol?: string; backend: string; prefix?: string }) {
         this.host = host;
+        this.protocol = protocol || 'http';
         this.basePath = `/(${backend})`;
         this.prefix = prefix || '';
     }
@@ -37,5 +39,5 @@ export class Client {
         this.getBasePath(opts) + (opts?.prefix !== false ? this.prefix : '') + route;
 
     getURL = (route: Route, opts?: Options) =>
-        `http://${this.getHost(opts)}${this.getPath(route, { ...opts, full: false })}`;
+        `${this.protocol}://${this.getHost(opts)}${this.getPath(route, { ...opts, full: false })}`;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -104,7 +104,7 @@ export async function getServerListConfig(dirname: string, protocol: string, hos
 
         return {
             name: type.charAt(0).toUpperCase() + type.slice(1),
-            logo: type === 'official' ? `http://${host}:${port}/(file)/logotype.svg` : undefined,
+            logo: type === 'official' ? `${protocol}://${host}:${port}/(file)/logotype.svg` : undefined,
             servers: serversOfType,
         };
     });


### PR DESCRIPTION
This PR updates internal URL generation to match the configured public protocol.

This solves the issue of mixed-content when serving the client via TLS; room-history (and other APIs) break when their XHR calls downgrade from TLS to unencrypted HTTP.