### PR TITLE
fix: Make sure objects have a string-typed key

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -411,6 +411,18 @@ koa.use(async (context, next) => {
                     'h.get("user/world-status").then(function(t){"empty"==t.status&&(P.selectedAction.action="spawn",',
                     'h.get("user/world-status").then(function(t){"empty"==t.status&&(',
                 );
+
+                // The server sometimes sends completely broken objects which break the viewer
+                // https://discord.com/channels/860665589738635336/1337213532198142044
+                // https://github.com/screeps/engine/blob/master/src/processor/intents/_create-energy.js#L49
+                // In this case, objects that were bulk-inserted this tick have an id that's a number
+                // This breaks because the for…in loop makes `o` a string, which the `_.find` call sees as different
+                // 'function U(e,t){for(var o in t){t[o]&&(t[o]._id=""+t[o]._id);var r=t[o],n=_.find(e,{_id:o});n?null!==r',
+                src = applyPatch(
+                    src,
+                    'function U(e,t){for(var o in t){var r=t[o],n=_.find(e,{_id:o});n?null!==r',
+                    'function U(e,t){for(var o in t){t[o]&&typeof t[o]._id!=="string"&&(t[o]._id=""+o);var r=t[o],n=_.find(e,{_id:o});n?null!==r',
+                );
             }
             return argv.beautify ? jsBeautify(src) : src;
         } else if (urlPath === 'components/profile/profile.html') {

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -145,7 +145,7 @@ const [data, stat] = await readPackageData();
 
 // Read package zip metadata
 const zip = new JSZip();
-await zip.loadAsync(data);
+await zip.loadAsync(new Uint8Array(data));
 
 // HTTP header is only accurate to the minute
 const lastModified = stat.mtime;

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -158,7 +158,7 @@ server.on('error', (err) => handleServerError(err, argv.debug));
 server.on('listening', () => {
     const hostport = port == 80 ? hostAddress : `${hostAddress}:${port}`;
     console.log('🌐', chalk.dim('Ready', arrow), chalk.white(`http://${hostport}/`));
-    if ((publicHostAddress != hostAddress) || (publicPort != argv.port) ) {
+    if (publicHostAddress != hostAddress || publicPort != argv.port) {
         const protocolPort = argv.public_tls ? 443 : 80;
         const public_hostport = publicPort == protocolPort ? publicHostAddress : `${publicHostAddress}:${publicPort}`;
         console.log('🌐', chalk.dim('Public', arrow), chalk.white(`${publicProtocol}://${public_hostport}/`));
@@ -187,8 +187,15 @@ koa.use(async (ctx, next) => {
 koa.use(async (context, next) => {
     if (['/', 'index.html'].includes(context.path)) {
         const communityPages = getCommunityPages();
-	const useSubdomains = publicHostAddress == 'localhost' || argv.use_subdomains;
-        let serverList = await getServerListConfig(__dirname, publicProtocol, publicHostAddress, publicPort, useSubdomains, argv.server_list);
+        const useSubdomains = publicHostAddress == 'localhost' || argv.use_subdomains;
+        const serverList = await getServerListConfig(
+            __dirname,
+            publicProtocol,
+            publicHostAddress,
+            publicPort,
+            useSubdomains,
+            argv.server_list,
+        );
         await context.render(indexFile, { serverList, communityPages });
     }
 

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -24,7 +24,17 @@ export class Client {
     private basePath: string;
     private prefix: string;
 
-    constructor({ host, protocol, prefix, backend }: { host: string; protocol?: string; backend: string; prefix?: string }) {
+    constructor({
+        host,
+        protocol,
+        prefix,
+        backend,
+    }: {
+        host: string;
+        protocol?: string;
+        backend: string;
+        prefix?: string;
+    }) {
         this.host = host;
         this.protocol = protocol || 'http';
         this.basePath = `/(${backend})`;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { URL } from 'url';
 import { Route, type Client } from './client';
 import { Server } from './types';
+import { logError } from './errors';
 
 export const mimeTypes = {
     '.css': 'text/css',
@@ -134,4 +135,12 @@ export function getCommunityPages(): { title: string; url: string }[] {
         { title: "Muon's blog", url: 'https://bencbartlett.com/blog/tag/screeps/' },
         { title: "Harabi's blog", url: 'https://sy-harabi.github.io/' },
     ];
+}
+
+export function applyPatch(data: string, original: string | RegExp, replace: string) {
+    const repl = data.replace(original, replace);
+    if (data.localeCompare(repl) === 0) {
+        logError(`failed to apply patch! "${original}"`);
+    }
+    return repl;
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -75,7 +75,14 @@ export function generateScriptTag(func: Function, args: { [key: string]: unknown
 /**
  * Utility to get the server list configuration.
  */
-export async function getServerListConfig(dirname: string, protocol: string, host: string, port: number, useSubdomains: boolean, serverListPath?: string) {
+export async function getServerListConfig(
+    dirname: string,
+    protocol: string,
+    host: string,
+    port: number,
+    useSubdomains: boolean,
+    serverListPath?: string,
+) {
     if (!serverListPath) {
         const serverListFile = 'server_list.json';
         serverListPath = path.join(dirname, `../settings/${serverListFile}`);
@@ -116,7 +123,10 @@ export function getCommunityPages(): { title: string; url: string }[] {
     return [
         { title: 'Screeps Wiki', url: 'https://wiki.screepspl.us/index.php/Screeps_Wiki' },
         { title: 'Community Grafana', url: 'https://pandascreeps.com/' },
-        { title: "MarvinTMB's videos", url: 'https://www.youtube.com/playlist?list=PLGlzrjCmziEj7hQZSwcmkXkMXgkQXUQ6C' },
+        {
+            title: "MarvinTMB's videos",
+            url: 'https://www.youtube.com/playlist?list=PLGlzrjCmziEj7hQZSwcmkXkMXgkQXUQ6C',
+        },
         {
             title: "Atanner's videos",
             url: 'https://www.youtube.com/watch?v=N7KMOG8C5vA&list=PLw9di5JwI6p-HUP0yPUxciaEjrsFb2kR2',


### PR DESCRIPTION
This fixes a bug with resource piles having the server use the
"bulk insert counter" as an id, which makes the `_.find()` check miss
them when the "object should be removed"/`null` gets processed in the
same chunk.

Based on #48.

Ref: https://github.com/screeps/engine/pull/146