### PR TITLE
feat: improve number formatting on the market page

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -340,6 +340,56 @@ koa.use(async (context, next) => {
                 src = applyPatch(src, /fetch\("https:\/\/screeps\.com\/forum\/.+\.rss"\)/g, 'Promise.resolve()');
                 // Remove AWS host from rewards URL
                 src = applyPatch(src, /https:\/\/s3\.amazonaws\.com/g, '');
+                // Replace some of the number formatting in the market pages
+
+                // # All orders
+                // Price + std on resource tiles: ./src2/app/market.module/resource-price.component/resource-price.component.pug
+                src = applyPatch(src, /{{ data\.avgPrice }}/g, '{{ data.avgPrice.toLocaleString() }}');
+                src = applyPatch(src, /{{ data\.stddevPrice }}/g, '{{ data.stddevPrice.toLocaleString() }}');
+
+                // # Resource info dialog
+                // Buying/selling tables, ./src2/app/market.module/table-orders/table-orders.component.pug
+                src = applyPatch(src, /{{ order\.price\.toFixed\(3\) }}/g, '{{ order.price.toLocaleString() }}');
+                src = applyPatch(src, /{{ order\.amount \| number }}/g, '{{ order.amount.toLocaleString() }}');
+                src = applyPatch(
+                    src,
+                    /{{ order\.remainingAmount \| number }}/g,
+                    '{{ order.remainingAmount.toLocaleString() }}',
+                );
+
+                // Price history, ./src2/app/market.module/table-price-history/table-price-history.component.pug
+                src = applyPatch(
+                    src,
+                    /{{ order.transactions\| number:'1\.0-3' }}/g,
+                    '{{ order.transactions.toLocaleString() }}',
+                );
+                src = applyPatch(src, /{{ order\.volume \| number:'1\.0-3'}}/g, '{{ order.volume.toLocaleString() }}');
+                src = applyPatch(src, /{{ order\.avgPrice }}/g, '{{ order.avgPrice.toLocaleString() }}');
+                src = applyPatch(
+                    src,
+                    /{{ order\.stddevPrice\.toFixed\(3\) }}/g,
+                    '{{ order.stddevPrice.toLocaleString() }}',
+                );
+
+                // # My orders, ./src2/app/market.module/table-my-orders/table-my-orders.component.pug
+                // There's also an `order.price` here, but it's been handled above
+                src = applyPatch(
+                    src,
+                    /{{ order\.totalAmount \| number }}/g,
+                    '{{ order.totalAmount.toLocaleString() }}',
+                );
+
+                // # History, ./src2/app/market.module/table-history/table-history.component.pug
+                src = applyPatch(src, /{{ transaction\.tick }}/g, '{{ transaction.tick.toLocaleString() }}');
+                src = applyPatch(
+                    src,
+                    /{{ transaction\.change\.toFixed\(3\) }}/g,
+                    '{{ transaction.change.toLocaleString() }}',
+                );
+                src = src.replaceAll(
+                    /{{ transaction\.balance\.toFixed\(3\) }}/g,
+                    '{{ transaction.balance.toLocaleString() }}',
+                );
             } else if (urlPath.startsWith('vendor/renderer/renderer.js')) {
                 // Modify renderer to remove AWS host from loadElement()
                 src = applyPatch(


### PR DESCRIPTION
This just switches all of them to `.toLocalString()` instead of Angular's default `number` or `toFixed(3)`.

Pictures for less words:
Resource list:
<img width="478" height="153" alt="Capture d’écran 2026-02-20 à 23 53 40" src="https://github.com/user-attachments/assets/a429c2f1-2187-4ac8-bc73-ba050baccd44" />
Buying/selling for resource:
<img width="728" height="77" alt="Capture d’écran 2026-02-20 à 23 53 49" src="https://github.com/user-attachments/assets/f5c952ae-af0e-479d-9cb2-467428a8f9ee" />
Price history for resource:
<img width="765" height="211" alt="Capture d’écran 2026-02-20 à 23 53 54" src="https://github.com/user-attachments/assets/5c5550e7-c94a-4a78-bdde-9f15fb23b53b" />
My orders:
<img width="1156" height="167" alt="Capture d’écran 2026-02-20 à 23 54 03" src="https://github.com/user-attachments/assets/b344c29c-0547-42d4-9717-0e9d4a264860" />
History:
<img width="1145" height="189" alt="Capture d’écran 2026-02-20 à 23 54 09" src="https://github.com/user-attachments/assets/8a23e184-43fe-4858-8381-3b2229fea46a" />

If those look weird I blame French 🥖.