### PR TITLE
feat: Fix the alpha map bounds locking for the season map

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -386,7 +386,8 @@ koa.use(async (context, next) => {
                     /{{ transaction\.change\.toFixed\(3\) }}/g,
                     '{{ transaction.change.toLocaleString() }}',
                 );
-                src = src.replaceAll(
+                src = applyPatch(
+                    src,
                     /{{ transaction\.balance\.toFixed\(3\) }}/g,
                     '{{ transaction.balance.toLocaleString() }}',
                 );

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -391,6 +391,17 @@ koa.use(async (context, next) => {
                     /{{ transaction\.balance\.toFixed\(3\) }}/g,
                     '{{ transaction.balance.toLocaleString() }}',
                 );
+
+                // Bounds fix for the alpha map
+                // ./node_modules/@screeps/map/dist/constants.js
+                src = applyPatch(src, /exports\.MIN_SCALE = \.4;/, 'exports.MIN_SCALE = .3');
+
+                // ./src2/app/world-map.module/world-map-size.resolver.ts
+                src = applyPatch(
+                    src,
+                    /resolve\({ width: width, height: height }\);/,
+                    "resolve(shard !== 'shardSeason' ? { width: width, height: height } : { width: 512, height: 512 });",
+                );
             } else if (urlPath.startsWith('vendor/renderer/renderer.js')) {
                 // Modify renderer to remove AWS host from loadElement()
                 src = applyPatch(


### PR DESCRIPTION
Given the 102x102 northern only season map, the map calculation assuming the center lies at 0x0 is incorrect. Since the server can't provide proper world bounds, just lie by making the world much bigger, so that the center isn't locked so tightly.