### PR TITLE
fix: switch arguments parser to commander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "license": "ISC",
             "dependencies": {
                 "@ladjs/koa-views": "^9.0.0",
-                "argparse": "2.0.1",
                 "chalk": "^5.3.0",
+                "commander": "^14.0.3",
                 "ejs": "^3.1.10",
                 "http-proxy": "1.18.1",
                 "http-proxy-middleware": "^3.0.0",
@@ -28,7 +28,6 @@
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-typescript": "^11.1.6",
-                "@types/argparse": "2.0.16",
                 "@types/http-proxy": "1.17.14",
                 "@types/js-beautify": "1.14.3",
                 "@types/koa": "2.15.0",
@@ -833,12 +832,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/argparse": {
-            "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.16.tgz",
-            "integrity": "sha512-aMqBra2JlqpFeCWOinCtpRpiCkPIXH8hahW2+FkGzvWjfE5sAqtOcrjN5DRcMnTQqFDe6gb1CVYuGnBH0lhXwA==",
-            "dev": true
-        },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1320,7 +1313,9 @@
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -1449,11 +1444,12 @@
             }
         },
         "node_modules/commander": {
-            "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "license": "MIT",
             "engines": {
-                "node": ">=14"
+                "node": ">=20"
             }
         },
         "node_modules/concat-map": {
@@ -1651,6 +1647,15 @@
             "bin": {
                 "editorconfig": "bin/editorconfig"
             },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "license": "MIT",
             "engines": {
                 "node": ">=14"
             }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
-        "@types/argparse": "2.0.16",
         "@types/http-proxy": "1.17.14",
         "@types/js-beautify": "1.14.3",
         "@types/koa": "2.15.0",
@@ -49,8 +48,8 @@
     },
     "dependencies": {
         "@ladjs/koa-views": "^9.0.0",
-        "argparse": "2.0.1",
         "chalk": "^5.3.0",
+        "commander": "^14.0.3",
         "ejs": "^3.1.10",
         "http-proxy": "1.18.1",
         "http-proxy-middleware": "^3.0.0",

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -1,5 +1,5 @@
 import views from '@ladjs/koa-views';
-import { ArgumentParser } from 'argparse';
+import { Command } from 'commander';
 import chalk from 'chalk';
 import { createReadStream, promises as fs } from 'fs';
 import httpProxy from 'http-proxy';
@@ -38,87 +38,56 @@ const localhost = 'localhost';
 const defaultPort = 8080;
 const awsHost = 'https://s3.amazonaws.com';
 
+interface Args {
+    package?: string;
+    host: string;
+    port: number;
+    public_hostname?: string;
+    public_port?: number;
+    public_tls: boolean;
+    use_subdomains: boolean;
+    internal_backend?: string;
+    server_list?: string;
+    guest: boolean;
+    beautify: boolean;
+    debug: boolean;
+}
+
 // Parse program arguments
-const argv = (() => {
-    const parser = new ArgumentParser({ description: 'Web proxy for the Screeps World game client.' });
-    parser.add_argument('-v', '--version', { action: 'version', version: `v${version}` });
-    parser.add_argument('--package', {
-        nargs: '?',
-        type: 'str',
-        help: "Path to the Screeps package.nw file. Use this if the path isn't automatically detected.",
-    });
-    parser.add_argument('--host', {
-        nargs: '?',
-        type: 'str',
-        default: localhost,
-        help: `Changes the host address. (default: ${localhost})`,
-    });
-    parser.add_argument('--port', {
-        nargs: '?',
-        type: 'int',
-        default: defaultPort,
-        help: `Changes the port. (default: ${defaultPort})`,
-    });
-    parser.add_argument('--public_hostname', {
-        nargs: '?',
-        type: 'str',
-        help: 'The hostname that clients can use to access the client; useful when running in a container.',
-    });
-    parser.add_argument('--public_port', {
-        nargs: '?',
-        type: 'int',
-        help: 'The port that clients can use to access the client; useful when running in a container.',
-    });
-    parser.add_argument('--public_tls', {
-        action: 'store_true',
-        default: false,
-        help: 'Whether the public address should use TLS; useful when running in a container.',
-    });
-    parser.add_argument('--use_subdomains', {
-        action: 'store_true',
-        default: false,
-        help: 'Whether the server links should use subdomains off of the public address.',
-    });
-    parser.add_argument('--internal_backend', {
-        nargs: '?',
-        type: 'str',
-        help: 'Set the internal backend url when running the Screeps server in a local container.',
-    });
-    parser.add_argument('--server_list', {
-        nargs: '?',
-        type: 'str',
-        help: 'Path to a custom server list json config file.',
-    });
-    parser.add_argument('--guest', {
-        action: 'store_true',
-        default: false,
-        help: 'Enable guest mode for xxscreeps.',
-    });
-    parser.add_argument('--beautify', {
-        action: 'store_true',
-        default: false,
-        help: 'Formats .js files loaded in the client for debugging.',
-    });
-    parser.add_argument('--debug', {
-        action: 'store_true',
-        default: false,
-        help: 'Display verbose errors for development.',
-    });
-    return parser.parse_args() as {
-        version?: boolean;
-        package?: string;
-        host: string;
-        port: number;
-        public_hostname?: string;
-        public_port?: number;
-        public_tls: boolean;
-        use_subdomains: boolean;
-        internal_backend?: string;
-        server_list?: string;
-        guest: boolean;
-        beautify: boolean;
-        debug: boolean;
-    };
+const argv: Args = (() => {
+    const program = new Command();
+    program
+        .name('screepers-steamless-client')
+        .description('Web proxy for the Screeps World game client.')
+        .version(version, '-v, --version', 'Display version number')
+        .option(
+            '--package <path>',
+            "Path to the Screeps package.nw file. Use this if the path isn't automatically detected.",
+        )
+        .option('--host <address>', `Changes the host address. (default: ${localhost})`, localhost)
+        .option('--port <number>', `Changes the port. (default: ${defaultPort})`, parseInt, defaultPort)
+        .option(
+            '--public_hostname <hostname>',
+            'The hostname that clients can use to access the client; useful when running in a container.',
+        )
+        .option(
+            '--public_port <number>',
+            'The port that clients can use to access the client; useful when running in a container.',
+            parseInt,
+        )
+        .option('--public_tls', 'Whether the public address should use TLS; useful when running in a container.', false)
+        .option('--use_subdomains', 'Whether the server links should use subdomains off of the public address.', false)
+        .option(
+            '--internal_backend <url>',
+            'Set the internal backend url when running the Screeps server in a local container.',
+        )
+        .option('--server_list <path>', 'Path to a custom server list json config file.')
+        .option('--guest', 'Enable guest mode for xxscreeps.', false)
+        .option('--beautify', 'Formats .js files loaded in the client for debugging.', false)
+        .option('--debug', 'Display verbose errors for development.', false);
+
+    program.parse();
+    return program.opts();
 })();
 
 /** The URL Steamless is listening at (possibly within a container) */


### PR DESCRIPTION
Replaced [argparse](https://www.npmjs.com/package/argparse) with [commander](https://www.npmjs.com/package/commander) for CLI argument parsing

Why

- Newer, widely used, active support
- Not a python port

  <img width="1156" height="400" alt="image" src="https://github.com/user-attachments/assets/c858911c-e4c1-4b7e-a326-0317960f2cc7" />

Helpful errors

  <img width="490" height="77" alt="image" src="https://github.com/user-attachments/assets/bf10fef4-56f3-4a7b-94ca-73864447a596" />
