### PR TITLE
fix: Investigate the version pop-up

### DIFF
--- a/src/patches/fixConfig.ts
+++ b/src/patches/fixConfig.ts
@@ -46,9 +46,23 @@ const patch: MultiPatch = {
         },
         {
             match: (url: string) => url === 'app2/main.js',
-            async apply(src: string) {
-                // Modify getData() to fetch from the correct API path
-                src = applyPatch(src, /fetch\(apiUrl \+ "version"\)/g, 'fetch(window.CONFIG.API_URL+"version")');
+            async apply(src: string, server: Server) {
+                // Some menu items have a config with an API_URL in them; try to transform them so they go through the proxy
+                const url = server.getPublicUrl({ backend: 'BACKEND' });
+                function urlReplacer(apiUrl: string) {
+                    const match = apiUrl.match(/^(https:\/\/screeps\.com\/(?:season\/)?)(.*)$/);
+                    if (!match) return apiUrl;
+                    const [backend, url] = [match[1] ?? '', match[2] ?? ''];
+                    return `URL`.replace('BACKEND', backend) + '/' + url;
+                }
+                let urlReplacerStr = urlReplacer.toString();
+                urlReplacerStr = applyPatch(urlReplacerStr, 'URL', url);
+                src = applyPatch(
+                    src,
+                    /this\._versionSrv\.getData\((item\.config\.API_URL)\)\.then\(function \(versionData\)/,
+                    `${urlReplacerStr}\nthis._versionSrv.getData(urlReplacer($1)).then(function (versionData)`,
+                );
+
                 // Remove fetch to forum RSS feed
                 src = applyPatch(src, /fetch\(RSS_FORUM_URL\)/g, 'Promise.resolve()');
                 return src;


### PR DESCRIPTION
This is not related to anything, but I was getting "forever" updates anytime I'd open Steamless, so I took a closer look. Turns out updates aren't distributed through Steam at all: I have to launch the native client from time to time for it to update itself, and I wasn't doing that.

Anyway, I looked closer at the patch we do to the version service, and it turns out there's two calls to it: one is from the current API_URL, so the patch is meaningless, the other comes from the season menu item putting that one's config into its structure. I have no idea what's that for, but for the sake of not blindly thinking everything must be `config.API_URL`, transform whatever menu item config into something the proxy can use.