### PR TITLE
feat: Force high-performance mode on the WebGL context

### DIFF
--- a/src/patches/highPerfWebGL.ts
+++ b/src/patches/highPerfWebGL.ts
@@ -1,0 +1,13 @@
+import { applyPatch, Patch } from './helpers';
+
+const patch: Patch = {
+    id: 'high-performance-webgl',
+    description: 'Forces WebGL canvas to use high-performance mode.',
+    disabled: true,
+    match: (url: string) => url === 'vendor/renderer/renderer.js',
+    async apply(src: string) {
+        src = applyPatch(src, 's.options.powerPreference', '"high-performance"');
+        return src;
+    },
+};
+export default patch;

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -10,6 +10,7 @@ import clientAuth from './clientAuth';
 import customMenuLinks from './customMenuLinks';
 import fixConfig from './fixConfig';
 import formatMarketNumbers from './formatMarketNumbers';
+import highPerfWebGL from './highPerfWebGL';
 import placeSpawnDefaultOff from './placeSpawnDefaultOff';
 import portalInfo from './portalInfo';
 import removeTracking from './removeTracking';
@@ -27,6 +28,7 @@ const patches: AnyPatch[] = [
     portalInfo,
     fixAlphaMapBounds,
     formatMarketNumbers,
+    highPerfWebGL,
     // Must be last
     beautify,
 ];


### PR DESCRIPTION
This adds a disabled patch to force the powerPreference WebGL option to `high-performance`. Not sure it really makes a difference, hence why I'm keeping it disabled.