### PR TITLE
feat: Enable stats viewing if the server supports it

### DIFF
--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -14,6 +14,7 @@ import highPerfWebGL from './highPerfWebGL';
 import placeSpawnDefaultOff from './placeSpawnDefaultOff';
 import portalInfo from './portalInfo';
 import removeTracking from './removeTracking';
+import serverStats from './serverStats';
 import stripAws from './stripAws';
 import terrainTilesProfileView from './terrainTilesProfileView';
 
@@ -29,6 +30,7 @@ const patches: AnyPatch[] = [
     fixAlphaMapBounds,
     formatMarketNumbers,
     highPerfWebGL,
+    serverStats,
     // Must be last
     beautify,
 ];

--- a/src/patches/serverStats.ts
+++ b/src/patches/serverStats.ts
@@ -1,0 +1,44 @@
+import { applyPatch, MultiPatch } from './helpers';
+
+const patch: MultiPatch = {
+    id: 'server-stats',
+    description: 'Enable stats viewing if the server supports it (needs screepsmod-stats installed)',
+    disabled: true,
+    patches: [
+        {
+            match: (url: string) => url === 'build.min.js',
+            async apply(src: string) {
+                // Add an hasFeature function to help with checking specific features from the HTML pages
+                src = applyPatch(
+                    src,
+                    't.Math=Math,t.isOffServer',
+                    't.Math=Math,t.hasFeature=function(feature){var f=m.get("Api").options.serverData.features;if(!f)return false;return f.some((feat)=>feat.name===feature);},t.isOffServer',
+                );
+                return src;
+            },
+        },
+        {
+            match: (url: string) => url === 'components/profile/profile.html',
+            async apply(src: string) {
+                src = applyPatch(
+                    src,
+                    "<div class='survival' ng-if='isOffServer()'>",
+                    "<div class='survival' ng-if='isOffServer() || hasFeature(\"screepsmod-stats\")'>",
+                );
+                src = applyPatch(
+                    src,
+                    "<div class='stats-controls' ng-if='isOffServer()'>",
+                    "<div class='stats-controls' ng-if='isOffServer() || hasFeature(\"screepsmod-stats\")'>",
+                );
+                src = applyPatch(
+                    src,
+                    "<app-profile-stats ng-if='isOffServer()' stats='Profile.data.stats'></app-profile-stats>",
+                    "<app-profile-stats ng-if='isOffServer() || hasFeature(\"screepsmod-stats\")' stats='Profile.data.stats'></app-profile-stats>",
+                );
+                return src;
+            },
+        },
+    ],
+};
+
+export default patch;


### PR DESCRIPTION
Another disabled by default patch. This one fixes (some of) the profile overview enough that it can show the stats, provided screepsmod-stats is enabled on the connected server (or it's one of the official ones). I don't think I fixed leaderboard pages, but it was good enough to show player stats on the profile.