### PR TITLE
fix: Clarify what to do to make the update available pop up go away

### DIFF
--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -17,6 +17,7 @@ import removeTracking from './removeTracking';
 import serverStats from './serverStats';
 import stripAws from './stripAws';
 import terrainTilesProfileView from './terrainTilesProfileView';
+import versionUpdate from './versionUpdate';
 
 const patches: AnyPatch[] = [
     fixConfig,
@@ -31,6 +32,7 @@ const patches: AnyPatch[] = [
     formatMarketNumbers,
     highPerfWebGL,
     serverStats,
+    versionUpdate,
     // Must be last
     beautify,
 ];

--- a/src/patches/versionUpdate.ts
+++ b/src/patches/versionUpdate.ts
@@ -1,0 +1,17 @@
+import { applyPatch, Patch } from './helpers';
+
+const patch: Patch = {
+    id: 'update-native-client',
+    description: 'Clarify the version updated pop up',
+    match: (url: string) => url === 'components/common/dlg-version-updated/dlg-version-updated.html',
+    async apply(src: string) {
+        src = applyPatch(
+            src,
+            /<span>New update is available<\/span>/,
+            '<span>Update available; launch the client through Steam.</span>',
+        );
+        return src;
+    },
+};
+
+export default patch;


### PR DESCRIPTION
This just adds a few words about having to launch the native client to get the updated version.