### PR TITLE
fix: Improved audio effects

### DIFF
--- a/src/inject/screepsAudio.ts
+++ b/src/inject/screepsAudio.ts
@@ -1,241 +1,289 @@
+interface GameObject {
+    _id?: string;
+    type?: string;
+    x?: number;
+    y?: number;
+    progress?: number;
+    invaderHarvested?: number;
+    energy?: number;
+    hits?: number;
+    actionLog?: {
+        upgradeController?: { x: number; y: number };
+        harvest?: { x: number; y: number };
+        build?: unknown;
+        repair?: { x: number; y: number };
+        attack?: unknown;
+        rangedAttack?: unknown;
+        rangedMassAttack?: unknown;
+        heal?: unknown;
+        rangedHeal?: unknown;
+    };
+}
+
 type TickData = {
-    [x: string]: { progress: number; invaderHarvested: number; energy: number; hits: number };
+    [objectId: string]: GameObject | null;
 };
 
-export function addScreepsAudio() {
-    console.log('Adding Screeps Audio');
-    let pTickData: TickData | undefined = undefined;
+interface GameEvent {
+    type: string;
+    timeStamp: number;
+    error: boolean;
+    edata: {
+        flags: string;
+        gameTime: number;
+        info: { mode: 'world' };
+        objects: TickData;
+        visual: string;
+    };
+}
+
+declare global {
+    interface Window {
+        audioDebug: boolean;
+    }
+}
+
+// eslint-disable-next-line
+declare var angular: any;
+// eslint-disable-next-line
+declare var _: any;
+
+export async function addScreepsAudio() {
+    window.audioDebug = false;
+    function log(...args: unknown[]) {
+        if (window.audioDebug) {
+            console.warn(...args);
+        }
+    }
+
+    log('Adding Screeps Audio');
+
+    /**
+     * Polls every 50 milliseconds for a given condition
+     */
+    async function waitFor(condition: () => boolean, pollInterval = 50, timeoutAfter?: number) {
+        // Track the start time for timeout purposes
+        const startTime = Date.now();
+
+        while (true) {
+            if (typeof timeoutAfter === 'number' && Date.now() > startTime + timeoutAfter) {
+                throw new Error('Condition not met before timeout');
+            }
+
+            const result = await condition();
+            if (result) {
+                return result;
+            }
+
+            await new Promise((r) => setTimeout(r, pollInterval));
+        }
+    }
 
     // this audio is under CC or whatever - but would be good to have it fully legal
     // we load it bunch of times, to have "fixed" memory usage and allow multiple-overlapping playbacks.
     // there is some cleaner way to do this probably
 
-    // https://freesound.org/people/The-Sacha-Rush/sounds/657818/
-    const repairAudio = [
-        new Audio('https://cdn.freesound.org/previews/657/657818_685248-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/657/657818_685248-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/657/657818_685248-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/657/657818_685248-lq.ogg'),
-    ];
-
-    // https://freesound.org/people/zagalo75/sounds/642314/
-    const moveAudio = [
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg'),
-    ];
-
-    // https://freesound.org/people/monosfera/sounds/789972/
-    const upgradeAudio = [new Audio('https://cdn.freesound.org/previews/789/789972_3625175-lq.ogg')];
-
-    // https://freesound.org/people/iut_Paris8/sounds/683923/
-    const damagedAudio = [
-        new Audio('https://cdn.freesound.org/previews/683/683923_907124-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/683/683923_907124-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/683/683923_907124-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/683/683923_907124-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/683/683923_907124-lq.ogg'),
-    ];
-
-    // https://freesound.org/people/FunnyVoices/sounds/709053/
-    const harvestAudio = [
-        new Audio('https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg'),
-        new Audio('https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg'),
-    ];
-
-    // we need to "hack" websocket constructor,
-    // to get access to websocket set-up by "original" screeps code (that is used to render game i.e)
-    // this needs to be loaded at-the-top, before "standard" code
-    const ws = window.WebSocket;
-    // @ts-expect-error just hacking
-    window.WebSocket = function (a, b) {
-        const that = b ? new ws(a, b) : new ws(a);
-        that.addEventListener('open', console.info.bind(console, 'socket open'));
-        that.addEventListener('close', console.info.bind(console, 'socket close'));
-        that.addEventListener('message', (m) => {
-            const parent = window.document.getElementsByClassName('room-controls-content')[0];
-            if (!parent) {
-                // not in room view
-                return;
-            }
-            const soundController = window.document.getElementById('audio-checkbox') as HTMLInputElement;
-            if (!soundController) {
-                const label = document.createElement('div');
-                label.innerHTML = `
-                <label>
-                <input id="audio-checkbox" type="checkbox" style="display:none">
-                <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" width="32px">
-                <path id="speaker-icon" fill="#adadadff" d="M275.5 96l-96 96h-96v128h96l96 96V96zm51.46 27.668l-4.66 17.387c52.066 13.95 88.2 61.04 88.2 114.945 0 53.904-36.134 100.994-88.2 114.945l4.66 17.387C386.81 372.295 428.5 317.962 428.5 256c0-61.963-41.69-116.295-101.54-132.332zm-12.425 46.365l-4.658 17.387C340.96 195.748 362.5 223.822 362.5 256s-21.54 60.252-52.623 68.58l4.658 17.387C353.402 331.552 380.5 296.237 380.5 256c0-40.238-27.098-75.552-65.965-85.967zm-12.424 46.363l-4.657 17.387C307.55 236.49 314.5 245.547 314.5 256s-6.95 19.51-17.047 22.217l4.658 17.387c17.884-4.792 30.39-21.09 30.39-39.604 0-18.513-12.506-34.812-30.39-39.604z"></path>
-                </svg>
-                </label>
-            `;
-                parent.appendChild(label);
-                return;
-            }
-            const icon = document.getElementById('speaker-icon');
-            if (!soundController.checked) {
-                console.log('>>>>>>>>>>> SCREEPS AUDIO DISABLED <<<<<<<<<<<<<<<<<<<<<<<');
-                icon?.setAttribute('fill', '#adadadff');
-                return;
-            }
-            icon?.setAttribute('fill', '#3f72b5ff');
-
-            // we skip all non-game-data websocket messages
-            if (!m.data) {
-                return;
-            }
-            if (m.data.includes('/console') || m.data.includes('/resources')) {
-                return;
-            }
-            // this part here is in preparation for using between-ticks game data (at some point)
-            // also makes it cheaper for searching for specific data later, since there is lot-less data to go through in case of visuals
-
-            // make parsing easier
-            let tickDataString = m.data.replace(/\\"/g, '"');
-            // remove visuals
-            tickDataString = tickDataString.split('"visual"')[0];
-
-            // split roomname data from front
-            tickDataString = tickDataString.split('{"objects":')[1];
-
-            if (!tickDataString?.length) {
-                // Whatever that was, it didn't contain objects
-                return;
-            }
-            // add back part of json
-            tickDataString = '{"objects":' + tickDataString;
-            // console.log(tickDataString)
-            // remove comma
-            tickDataString = tickDataString.slice(0, -1);
-            // console.log(tickDataString)
-            // add missing parenthesis so this is valid json
-            tickDataString += '}';
-            console.log(tickDataString);
-
-            /**
-             *   naive way of generating sound effect,based on only object delta obtained from websocket
-             */
-            // repair sounds - repair action log
-            // const repairCount = (tickDataString.match(/repair/g) || []).length;
-            // if(repairCount) {
-            //     console.log(`repairCount: ${repairCount}`)
-            //     for(let i = 0; i < Math.min(repairAudio.length, repairCount); i++) {
-            //         setTimeout(() => {
-            //             repairAudio[i].load()
-            //             repairAudio[i].play()
-            //         }, Math.random()*300);
-            //     }
-            // }
-            // harvest sounds - invader harvested changesinceaction log is not sure
-            // const harvestCount = (tickDataString.match(/invaderHarvested/g) || []).length;
-            // if(harvestCount) {
-            //     console.log(`harvestCount: ${harvestCount}`)
-            //     for(let i = 0; i < Math.min(harvestAudio.length, harvestCount); i++) {
-            //         setTimeout(() => {
-            //             harvestAudio[i].load()
-            //             harvestAudio[i].play()
-            //         }, Math.random()*300);
-            //     }
-            // }
-            // // upgrade sounds - change of controller progress
-            // const upgrade = (tickDataString.match(/progress/g) || []).length;
-            // if(upgrade) {
-            //     console.log(`upgrade: ${upgrade}`)
-            //     upgradeAudio[0].load()
-            //     upgradeAudio[0].play()
-            // }
-            // move sounds - change of room-objects coords
-            const moveCount = Math.max(
-                (tickDataString.match(/"x"/g) || []).length,
-                (tickDataString.match(/"y"/g) || []).length,
-            );
-
-            if (moveCount) {
-                console.log(`moveCount: ${moveCount}`);
-                for (let i = 0; i < Math.min(moveAudio.length, moveCount); i++) {
-                    setTimeout(() => {
-                        moveAudio[i].load();
-                        moveAudio[i].play();
-                    }, Math.random() * 300);
-                }
-            }
-
-            /**
-             * Better way of generating sounds by comparing tick data across 2 ticks
-             */
-            let currentTickDataObj: TickData;
-            try {
-                currentTickDataObj = JSON.parse(tickDataString).objects;
-            } catch {
-                console.log(`failed to parse ${tickDataString}`);
-                return;
-            }
-            if (!pTickData) {
-                pTickData = JSON.parse(tickDataString).objects;
-                return;
-            }
-
-            let harvestIndex = 0; // so every source has own harvest-sound
-            let repairIndex = 0; // so "almost" every repair has own sound
-
-            const changedObjects = Object.keys(currentTickDataObj);
-            for (const id of changedObjects) {
-                // controller being upgraded sound (max 1)
-                if (currentTickDataObj[id].progress && pTickData[id] && pTickData[id]?.progress) {
-                    if (currentTickDataObj[id].progress > pTickData[id].progress) {
-                        console.log(
-                            `controller upgraded ${pTickData[id].progress} -> ${currentTickDataObj[id].progress}`,
-                        );
-                        upgradeAudio[0].load();
-                        upgradeAudio[0].play();
-                    }
-                    continue;
-                }
-
-                // source energy harvested sound (max 3 in SK rooms)
-                if (currentTickDataObj[id].invaderHarvested && currentTickDataObj[id].energy && pTickData[id]?.energy) {
-                    if (currentTickDataObj[id].energy < pTickData[id].energy) {
-                        console.log(`Source ${id} harvested`);
-                        setTimeout(() => {
-                            harvestAudio[Math.min(harvestIndex, 3)].load();
-                            harvestAudio[Math.min(harvestIndex, 3)].play();
-                        }, Math.random() * 300);
-                        harvestIndex++;
-                    }
-                    continue;
-                }
-
-                // repair / dmg sounds
-                if (currentTickDataObj[id].hits && pTickData[id]?.hits) {
-                    if (currentTickDataObj[id].hits > pTickData[id].hits) {
-                        console.log(`Object ${id} repaired/healed`);
-                        setTimeout(() => {
-                            repairAudio[Math.min(repairIndex, repairAudio.length)].load();
-                            repairAudio[Math.min(repairIndex, repairAudio.length)].play();
-                        }, Math.random() * 300);
-                        repairIndex++;
-                    }
-                    if (currentTickDataObj[id].hits < pTickData[id].hits) {
-                        console.log(`Object ${id} damaged`);
-                        setTimeout(() => {
-                            damagedAudio[Math.min(repairIndex, damagedAudio.length)].load();
-                            damagedAudio[Math.min(repairIndex, damagedAudio.length)].play();
-                        }, Math.random() * 300);
-                        repairIndex++;
-                    }
-                }
-            }
-            pTickData = currentTickDataObj;
-        });
-        return that;
+    const soundEffects: { [soundEffect: string]: { url: string; volume: number; buffer?: AudioBuffer } } = {
+        // https://freesound.org/people/zagalo75/sounds/642314/
+        move: { url: 'https://cdn.freesound.org/previews/642/642314_11167166-lq.ogg', volume: 0.6 },
+        // https://freesound.org/people/The-Sacha-Rush/sounds/657818/
+        repair: { url: 'https://cdn.freesound.org/previews/657/657818_685248-lq.ogg', volume: 0.7 },
+        // https://freesound.org/people/monosfera/sounds/789972/
+        upgrade: { url: 'https://cdn.freesound.org/previews/789/789972_3625175-lq.ogg', volume: 0.3 },
+        // https://freesound.org/people/iut_Paris8/sounds/683923/
+        damage: { url: 'https://cdn.freesound.org/previews/683/683923_907124-lq.ogg', volume: 1.0 },
+        // https://freesound.org/people/FunnyVoices/sounds/709053/
+        harvest: { url: 'https://cdn.freesound.org/previews/709/709053_12187251-lq.ogg', volume: 0.5 },
+        // https://freesound.org/people/lulyc/sounds/346116/
+        heal: { url: 'https://cdn.freesound.org/previews/346/346116_6051514-lq.ogg', volume: 0.6 },
     };
 
-    window.WebSocket.prototype = ws.prototype;
+    // XXX: would work better if we kept track of the average tick length
+    let tickTime = 2000;
+    let lastReceivedUpdate: number | undefined;
+
+    const audioCtx = new AudioContext();
+
+    async function playSoundEffect(sound: keyof typeof soundEffects) {
+        const effect = soundEffects[sound];
+        if (!effect) return;
+        if (!effect.buffer) {
+            const res = await fetch(effect.url);
+            const buf = await res.arrayBuffer();
+            effect.buffer = await audioCtx.decodeAudioData(buf);
+        }
+
+        const audio = audioCtx.createBufferSource();
+        audio.buffer = effect.buffer;
+
+        const gain = audioCtx.createGain();
+        gain.gain.value = effect.volume;
+
+        audio.connect(gain).connect(audioCtx.destination);
+
+        // We're gonna use our tick length estimate to "scatter" the sound effects around at random.
+        // This should help in not having overlap like crazy, making them way too loud.
+        const soundOffset = Math.round(tickTime * Math.random());
+
+        setTimeout(() => {
+            log(`playing ${sound} at ${effect.volume} (offset: ${soundOffset})`);
+            audio.start();
+        }, soundOffset);
+        return;
+    }
+
+    function isSoundEnabled() {
+        return sessionStorage.getItem('screeps-audio.enabled') === 'true';
+    }
+    function setSoundEnabled(enabled: boolean) {
+        sessionStorage.setItem('screeps-audio.enabled', `${enabled}`);
+    }
+
+    async function injectUI() {
+        log('waiting to inject UI…');
+        await waitFor(() => !!document.getElementsByClassName('room-controls-content')?.[0]);
+
+        const roomControls = document.getElementsByClassName('room-controls-content')[0];
+        log('injecting UI');
+
+        const SOUND_EFFECT_BUTTON_ID = 'audio-button';
+
+        let audioButton = document.getElementById(SOUND_EFFECT_BUTTON_ID) as HTMLButtonElement;
+        if (!audioButton) {
+            const soundButtonHTML = `<button id='${SOUND_EFFECT_BUTTON_ID}' class='md-fab md-button ng-scope md-ink-ripple' type='button' aria-label='Sound Effects' tooltip-append-to-body='true' tooltip-placement='bottom' uib-tooltip='Sound Effects'>
+                <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" width="32px">
+                <path fill="${isSoundEnabled() ? '#3f72b5ff' : '#adadadff'}" d="M275.5 96l-96 96h-96v128h96l96 96V96zm51.46 27.668l-4.66 17.387c52.066 13.95 88.2 61.04 88.2 114.945 0 53.904-36.134 100.994-88.2 114.945l4.66 17.387C386.81 372.295 428.5 317.962 428.5 256c0-61.963-41.69-116.295-101.54-132.332zm-12.425 46.365l-4.658 17.387C340.96 195.748 362.5 223.822 362.5 256s-21.54 60.252-52.623 68.58l4.658 17.387C353.402 331.552 380.5 296.237 380.5 256c0-40.238-27.098-75.552-65.965-85.967zm-12.424 46.363l-4.657 17.387C307.55 236.49 314.5 245.547 314.5 256s-6.95 19.51-17.047 22.217l4.658 17.387c17.884-4.792 30.39-21.09 30.39-39.604 0-18.513-12.506-34.812-30.39-39.604z"></path>
+                </svg>
+                </button>`;
+            const soundButton = angular.element(soundButtonHTML);
+            soundButton.appendTo(roomControls);
+            audioButton = document.getElementById(SOUND_EFFECT_BUTTON_ID) as HTMLButtonElement;
+        }
+
+        audioButton.addEventListener('click', () => {
+            const enabled = !isSoundEnabled();
+            setSoundEnabled(enabled);
+            const icon = document.querySelector(`#${SOUND_EFFECT_BUTTON_ID} path`)!;
+            if (enabled) {
+                icon.setAttribute('fill', '#3f72b5ff');
+            } else {
+                icon.setAttribute('fill', '#adadadff');
+            }
+        });
+    }
+
+    function playSounds() {
+        if (!isSoundEnabled()) return;
+        for (const id in currentTickData?.objects) {
+            const object = currentTickData.objects[id];
+            const lastObject = lastTickData?.objects[id];
+            if (!object) continue;
+
+            if (object.type === 'creep' || object.type === 'powerCreep') {
+                const lastPos = { x: lastObject?.x, y: lastObject?.y };
+                const currPos = { x: object.x, y: object.y };
+                if (lastPos.x !== currPos.x || lastPos.y !== currPos.y) {
+                    playSoundEffect('move');
+                }
+            }
+
+            if (object.actionLog?.upgradeController) {
+                playSoundEffect('upgrade');
+            } else if (object.actionLog?.harvest) {
+                playSoundEffect('harvest');
+            } else if (object.actionLog?.repair || object.actionLog?.build) {
+                playSoundEffect('repair');
+            } else if (object.actionLog?.heal) {
+                playSoundEffect('heal');
+            } else if (
+                object.actionLog?.attack ||
+                object.actionLog?.rangedAttack ||
+                object.actionLog?.rangedMassAttack
+            ) {
+                playSoundEffect('damage');
+            }
+        }
+    }
+
+    let lastTickData: GameEvent['edata'] | undefined;
+    let currentTickData: GameEvent['edata'] | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let currentTickDiff: GameEvent['edata'] | undefined;
+
+    function onRoomTick(evt: GameEvent) {
+        const currentUpdate = Date.now();
+        if (lastReceivedUpdate !== undefined) {
+            tickTime = (tickTime + (currentUpdate - lastReceivedUpdate)) / 2;
+        }
+        lastReceivedUpdate = currentUpdate;
+        log('roomTick:', atob(evt.type), evt.timeStamp, tickTime);
+
+        if (currentTickData) {
+            currentTickData = _.merge(currentTickData, evt.edata);
+        } else {
+            currentTickData = evt.edata;
+        }
+        currentTickDiff = evt.edata;
+
+        playSounds();
+
+        lastTickData = structuredClone(currentTickData);
+    }
+
+    let currentSub: string | null = null;
+    function subscribeSocket(path: string | null) {
+        const Socket = angular.element(document.body).injector().get('Socket');
+        if (currentSub === path) {
+            return;
+        } else if (path) {
+            if (currentSub) {
+                log(`already subscribed to ${currentSub}, unsubscribing`);
+                lastTickData = undefined;
+                currentTickData = undefined;
+                currentTickDiff = undefined;
+                Socket.off(currentSub);
+                currentSub = null;
+            }
+            currentSub = path;
+            log(`subscribing to ${path}`);
+            Socket.on(currentSub, onRoomTick);
+        } else {
+            log(`unsubscribing from ${currentSub}`);
+            lastTickData = undefined;
+            currentTickData = undefined;
+            currentTickDiff = undefined;
+            Socket.off(currentSub);
+            currentSub = null;
+        }
+    }
+
+    let currentRoom: string | undefined;
+    document.addEventListener('readystatechange', async () => {
+        await waitFor(() => !!angular.element(document.body).injector());
+
+        const rootScope = angular.element(document.body).scope();
+        rootScope.$watch(
+            () => window.location.hash,
+            async function () {
+                try {
+                    const $routeParams = angular.element(document.body).injector().get('$routeParams');
+                    if ($routeParams.room) {
+                        if (currentRoom === $routeParams.room) return;
+                        currentRoom = $routeParams.room;
+
+                        await waitFor(() => !!angular.element('.room.ng-scope').scope());
+                        const Room = angular.element('.room.ng-scope').scope().Room;
+
+                        injectUI();
+
+                        subscribeSocket(`room:${Room.shardName}/${Room.roomName}`);
+                    } else {
+                        subscribeSocket(null);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            },
+        );
+    });
 }


### PR DESCRIPTION
Rework the handling to attach to the game socket instead of hacking the WebSocket prototype. This means we can just piggy-back on the data processing it does instead of hand-rolling it.

Now that we can rebuild the entire object graph from each tick delta, track events through `actionLog`s instead of guessing at what's happening.

Use the WebAudio API to get rid of the sound limit, apply gain, and "scatter" around sounds so they don't overlap too much.

Add 'heal' sound effect, move the icon inline with the other buttons and save the sound effect state in `sessionStorage`. This keeps it active while navigating in one tab, but it still defaults to disabled on open.