### PR TITLE
fix: pservers failing to loading terrain tiles

### DIFF
--- a/src/patches/fixConfig.ts
+++ b/src/patches/fixConfig.ts
@@ -75,28 +75,13 @@ const patch: MultiPatch = {
                 // Load backend info from underlying server
                 const backendURL = new URL(backend);
                 const isOfficialLike = isOfficial || (await isOfficialLikeVersion(server));
+
                 // Look for server options payload in build information
-                for (const match of src.matchAll(/\boptions=\{/g)) {
-                    for (let i = match.index!; i < src.length; ++i) {
-                        if (src.charAt(i) === '}') {
-                            try {
-                                const payload = src.substring(match.index!, i + 1);
-                                if (payload.includes('apiUrl')) {
-                                    // Inject host, port, and official
-                                    src = `${src.substring(0, i)},
-                                                    host: ${JSON.stringify(backendURL.hostname)},
-                                                    protocol: "${backendURL.protocol}",
-                                                    port: ${backendURL.port || (backendURL.protocol === 'https:' ? '443' : '80')},
-                                                    official: ${isOfficialLike},
-                                                } ${src.substring(i + 1)}`;
-                                }
-                                break;
-                            } catch {
-                                //
-                            }
-                        }
-                    }
-                }
+                src = applyPatch(
+                    src,
+                    /(var t=this\.options={apiUrl:""),official:![0|1],(serverData:)/g,
+                    `$1,official:${isOfficialLike},protocol:"${backendURL.protocol}",host:"${backendURL.hostname}",port:${backendURL.port || (backendURL.protocol === 'https:' ? '443' : '80')},$2`,
+                );
                 if (!isOfficial) {
                     // Replace room-history URL
                     src = applyPatch(

--- a/src/patches/fixConfig.ts
+++ b/src/patches/fixConfig.ts
@@ -10,7 +10,7 @@ const patch: MultiPatch = {
         {
             match: (url: string) => url === 'config.js',
             async apply(src: string, server: Server, argv: Args) {
-                const opts: ServerOptions = { backend: true, path: false };
+                const opts: ServerOptions = { hostUrl: false, backend: true, path: false };
 
                 // Replace API_URL, HISTORY_URL, WEBSOCKET_URL, and PREFIX in the server config
                 const apiPath = server.getURL(Route.API, opts);
@@ -106,7 +106,11 @@ const patch: MultiPatch = {
                     );
 
                     // Replace official CDN with local assets
-                    src = applyPatch(src, /https:\/\/d3os7yery2usni\.cloudfront\.net/g, `${backendURL}/assets`);
+                    src = applyPatch(
+                        src,
+                        /https:\/\/d3os7yery2usni\.cloudfront\.net/g,
+                        server.getURL(Route.ASSETS, { hostUrl: false, path: false }),
+                    );
                 }
 
                 // Replace URLs with local client paths

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -1,5 +1,7 @@
 export const AWS_HOST = 'https://s3.amazonaws.com';
 export interface ServerOptions {
+    /** Whether to include the host in the final URL  */
+    hostUrl?: boolean;
     /** Whether to include the backend in the final URL. If a string is passed, it'll be used as an override backend URL */
     backend?: boolean | string;
     /** Whether to add the subdomain to the public host */
@@ -147,15 +149,16 @@ export class Server {
     /**
      * Build a complete server url for a Screeps server
      */
-    getPublicUrl(opts?: Pick<ServerOptions, 'backend' | 'subdomain'>) {
+    getPublicUrl(opts?: Pick<ServerOptions, 'backend' | 'subdomain' | 'hostUrl'>) {
         const subdomain = this.subdomain && opts?.subdomain !== false ? `${this.subdomain}.` : '';
         const port =
             this.port &&
             ((this.protocol === 'http:' && this.port !== '80') || (this.protocol === 'https:' && this.port !== '443'))
                 ? `:${this.port}`
                 : '';
-        const backend = opts?.backend !== false ? `/(${this._getBackendUrl(opts)})` : '';
-        return `${this.protocol}//${subdomain}${this.host}${port}${backend}`;
+        const domain = opts?.hostUrl !== false ? `${this.protocol}//${subdomain}${this.host}${port}/` : '/';
+        const backend = opts?.backend !== false ? `(${this._getBackendUrl(opts)})` : '';
+        return `${domain}${backend}`;
     }
 
     /**


### PR DESCRIPTION
Not sure what happened there. The options should look like this:
```
var t = this.options = {
  apiUrl: "",
  official: !0,
  serverData: {
    historyChunkSize: 100,
    shards: []
  }
};
```
I'm guessing a client update silently changed that in such a way that the patch we had ended up putting stuff inside `serverData`, which stopped `official` from being toggled off? Since the "official" mode has hardcoded URLs and we fix those anyway, it had no effect on those, but the pservers end up trying to go through the same path, the URL ends up invalid there, and no terrain tiles load.

Ended up redoing the patch to have proper reporting in case we can't apply it. Also tweaked the URL slightly since I was looking around at the differences between v1.17.0 and `main`.