### PR TITLE
fix: Update for the 'Node 24' client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,8 @@
                 "rollup": "^4.59.0",
                 "rollup-plugin-shebang-bin": "^0.1.0",
                 "tslib": "^2.8.1",
-                "typescript": "5.9.3",
-                "typescript-eslint": "^8.56.1"
+                "typescript": "^6.0.2",
+                "typescript-eslint": "^8.58.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -1166,20 +1166,20 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-            "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
+            "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/type-utils": "8.56.1",
-                "@typescript-eslint/utils": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/type-utils": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1189,9 +1189,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.56.1",
+                "@typescript-eslint/parser": "^8.58.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1205,16 +1205,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-            "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
+            "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1226,18 +1226,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-            "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+            "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.56.1",
-                "@typescript-eslint/types": "^8.56.1",
+                "@typescript-eslint/tsconfig-utils": "^8.58.0",
+                "@typescript-eslint/types": "^8.58.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1248,18 +1248,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-            "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+            "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1"
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1270,9 +1270,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-            "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+            "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1283,21 +1283,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-            "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
+            "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1",
-                "@typescript-eslint/utils": "8.56.1",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1308,13 +1308,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-            "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+            "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1326,21 +1326,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-            "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+            "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.56.1",
-                "@typescript-eslint/tsconfig-utils": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
+                "@typescript-eslint/project-service": "8.58.0",
+                "@typescript-eslint/tsconfig-utils": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/visitor-keys": "8.58.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1350,20 +1350,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-            "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+            "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1"
+                "@typescript-eslint/scope-manager": "8.58.0",
+                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1374,17 +1374,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-            "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+            "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
+                "@typescript-eslint/types": "8.58.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3779,9 +3779,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3835,9 +3835,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -3849,16 +3849,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
-            "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+            "version": "8.58.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
+            "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.56.1",
-                "@typescript-eslint/parser": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1",
-                "@typescript-eslint/utils": "8.56.1"
+                "@typescript-eslint/eslint-plugin": "8.58.0",
+                "@typescript-eslint/parser": "8.58.0",
+                "@typescript-eslint/typescript-estree": "8.58.0",
+                "@typescript-eslint/utils": "8.58.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3869,7 +3869,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "rollup": "^4.59.0",
         "rollup-plugin-shebang-bin": "^0.1.0",
         "tslib": "^2.8.1",
-        "typescript": "5.9.3",
-        "typescript-eslint": "^8.56.1"
+        "typescript": "^6.0.2",
+        "typescript-eslint": "^8.58.0"
     },
     "dependencies": {
         "@ladjs/koa-views": "^9.0.0",

--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -10,11 +10,11 @@ import koaConditionalGet from 'koa-conditional-get';
 import path from 'path';
 import { Transform } from 'stream';
 import { URL, fileURLToPath } from 'url';
-import { AWS_HOST, Server } from './utils/server';
-import { handleProxyError, handleServerError, logError } from './utils/errors';
-import { getScreepsPath } from './utils/gamePath';
-import { getCommunityPages, getServerListConfig, mimeTypes } from './utils/utils';
-import { applyPatches, checkPatches, hasPatches, listPatches } from 'patches';
+import { AWS_HOST, Server } from './utils/server.js';
+import { handleProxyError, handleServerError, logError } from './utils/errors.js';
+import { getScreepsPath } from './utils/gamePath.js';
+import { getCommunityPages, getServerListConfig, mimeTypes } from './utils/utils.js';
+import { applyPatches, checkPatches, hasPatches, listPatches } from './patches/index.js';
 
 // Get the app directory and version
 const __filename = fileURLToPath(import.meta.url);

--- a/src/patches/beautify.ts
+++ b/src/patches/beautify.ts
@@ -1,7 +1,7 @@
-import { Patch } from './helpers';
+import { Patch } from './helpers.js';
 import jsBeautify from 'js-beautify';
-import { Server } from 'utils/server';
-import { Args } from 'clientApp';
+import { Server } from '../utils/server.js';
+import { Args } from '../clientApp.js';
 
 const patch: Patch = {
     id: 'beautify',

--- a/src/patches/clientAuth.ts
+++ b/src/patches/clientAuth.ts
@@ -1,8 +1,8 @@
-import { Args } from '../clientApp';
-import { clientAuth } from '../inject/clientAuth';
-import { Server } from '../utils/server';
-import { generateScriptTag } from '../utils/utils';
-import { applyPatch, Patch } from './helpers';
+import { Args } from '../clientApp.js';
+import { clientAuth } from '../inject/clientAuth.js';
+import { Server } from '../utils/server.js';
+import { generateScriptTag } from '../utils/utils.js';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'client-auth',

--- a/src/patches/customMenuLinks.ts
+++ b/src/patches/customMenuLinks.ts
@@ -1,7 +1,7 @@
-import { customMenuLinks } from '../inject/customMenuLinks';
-import { Route, Server } from '../utils/server';
-import { generateScriptTag } from '../utils/utils';
-import { applyPatch, Patch } from './helpers';
+import { customMenuLinks } from '../inject/customMenuLinks.js';
+import { Route, Server } from '../utils/server.js';
+import { generateScriptTag } from '../utils/utils.js';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'custom-menu-links',

--- a/src/patches/fixAlphaMapBounds.ts
+++ b/src/patches/fixAlphaMapBounds.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'fix-alpha-map-bounds',

--- a/src/patches/fixConfig.ts
+++ b/src/patches/fixConfig.ts
@@ -63,8 +63,6 @@ const patch: MultiPatch = {
                     `${urlReplacerStr}\nthis._versionSrv.getData(urlReplacer($1)).then(function (versionData)`,
                 );
 
-                // Remove fetch to forum RSS feed
-                src = applyPatch(src, /fetch\(RSS_FORUM_URL\)/g, 'Promise.resolve()');
                 return src;
             },
         },

--- a/src/patches/fixConfig.ts
+++ b/src/patches/fixConfig.ts
@@ -1,7 +1,7 @@
-import { Args } from 'clientApp';
-import { Route, Server, ServerOptions } from 'utils/server';
-import { isOfficialLikeVersion } from 'utils/utils';
-import { applyPatch, MultiPatch } from './helpers';
+import { Args } from '../clientApp.js';
+import { Route, Server, ServerOptions } from '../utils/server.js';
+import { isOfficialLikeVersion } from '../utils/utils.js';
+import { applyPatch, MultiPatch } from './helpers.js';
 
 const patch: MultiPatch = {
     id: 'fix-config',

--- a/src/patches/formatMarketNumbers.ts
+++ b/src/patches/formatMarketNumbers.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'format-market-numbers',

--- a/src/patches/helpers.ts
+++ b/src/patches/helpers.ts
@@ -1,5 +1,5 @@
-import { Args } from 'clientApp';
-import { Server } from 'utils/server';
+import { Args } from '../clientApp.js';
+import { Server } from '../utils/server.js';
 
 interface Patcher {
     match: (url: string) => boolean;

--- a/src/patches/highPerfWebGL.ts
+++ b/src/patches/highPerfWebGL.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'high-performance-webgl',

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -11,6 +11,7 @@ import customMenuLinks from './customMenuLinks.js';
 import fixConfig from './fixConfig.js';
 import formatMarketNumbers from './formatMarketNumbers.js';
 import highPerfWebGL from './highPerfWebGL.js';
+import normalizeStringPosix from './normalizeStringPosix.js';
 import placeSpawnDefaultOff from './placeSpawnDefaultOff.js';
 import portalInfo from './portalInfo.js';
 import removeTracking from './removeTracking.js';
@@ -24,6 +25,7 @@ const patches: AnyPatch[] = [
     fixConfig,
     stripAws,
     clientAuth,
+    normalizeStringPosix,
     customMenuLinks,
     removeTracking,
     terrainTilesProfileView,

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -1,24 +1,24 @@
-import { AnyPatch, PatchError } from './helpers';
-import { Server } from 'utils/server';
-import { Args } from 'clientApp';
-import { logError } from 'utils/errors';
+import { AnyPatch, PatchError } from './helpers.js';
+import { Server } from '../utils/server.js';
+import { Args } from '../clientApp.js';
+import { logError } from '../utils/errors.js';
 import chalk from 'chalk';
 
-import beautify from './beautify';
-import fixAlphaMapBounds from './fixAlphaMapBounds';
-import clientAuth from './clientAuth';
-import customMenuLinks from './customMenuLinks';
-import fixConfig from './fixConfig';
-import formatMarketNumbers from './formatMarketNumbers';
-import highPerfWebGL from './highPerfWebGL';
-import placeSpawnDefaultOff from './placeSpawnDefaultOff';
-import portalInfo from './portalInfo';
-import removeTracking from './removeTracking';
-import serverStats from './serverStats';
-import screepsAudio from './screepsAudio';
-import stripAws from './stripAws';
-import terrainTilesProfileView from './terrainTilesProfileView';
-import versionUpdate from './versionUpdate';
+import beautify from './beautify.js';
+import fixAlphaMapBounds from './fixAlphaMapBounds.js';
+import clientAuth from './clientAuth.js';
+import customMenuLinks from './customMenuLinks.js';
+import fixConfig from './fixConfig.js';
+import formatMarketNumbers from './formatMarketNumbers.js';
+import highPerfWebGL from './highPerfWebGL.js';
+import placeSpawnDefaultOff from './placeSpawnDefaultOff.js';
+import portalInfo from './portalInfo.js';
+import removeTracking from './removeTracking.js';
+import serverStats from './serverStats.js';
+import screepsAudio from './screepsAudio.js';
+import stripAws from './stripAws.js';
+import terrainTilesProfileView from './terrainTilesProfileView.js';
+import versionUpdate from './versionUpdate.js';
 
 const patches: AnyPatch[] = [
     fixConfig,

--- a/src/patches/normalizeStringPosix.ts
+++ b/src/patches/normalizeStringPosix.ts
@@ -1,0 +1,20 @@
+import { applyPatch, Patch } from './helpers.js';
+
+const patch: Patch = {
+    id: 'normalize-string-posix',
+    description: 'Protect URL-like shenanigans',
+    match: (url: string) => url === 'vendor/renderer/renderer.js',
+    async apply(src: string) {
+        // `normalizeStringPosix`, a Pixi function, gets passed our janky URLs
+        // thinking they're paths. Protect the :// from them so those don't get folded
+        // and break loading of user badges
+        src = applyPatch(
+            src,
+            /if \(code === 47\) {/,
+            'if (code === 47 && !(i > 0 && path2.charCodeAt(i - 1) === 58)) {',
+        );
+        return src;
+    },
+};
+
+export default patch;

--- a/src/patches/placeSpawnDefaultOff.ts
+++ b/src/patches/placeSpawnDefaultOff.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'place-spawn-default-off',

--- a/src/patches/portalInfo.ts
+++ b/src/patches/portalInfo.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'portal-info',

--- a/src/patches/removeTracking.ts
+++ b/src/patches/removeTracking.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'remove-tracking',

--- a/src/patches/removeTracking.ts
+++ b/src/patches/removeTracking.ts
@@ -32,6 +32,11 @@ const patch: Patch = {
         );
         src = applyPatch(
             src,
+            /<script[^>]*>[^>]*redditstatic.com\/ads\/pixel\.js[^>]*<\/script>/g,
+            '<script>reddit = new Proxy(() => reddit, { get: () => reddit })</script>',
+        );
+        src = applyPatch(
+            src,
             /<script[^>]*>[^>]*onRecaptchaLoad[^>]*<\/script>/g,
             '<script>function onRecaptchaLoad(){}</script>',
         );

--- a/src/patches/screepsAudio.ts
+++ b/src/patches/screepsAudio.ts
@@ -1,6 +1,6 @@
-import { addScreepsAudio } from 'inject/screepsAudio';
-import { generateScriptTag } from '../utils/utils';
-import { applyPatch, Patch } from './helpers';
+import { addScreepsAudio } from '../inject/screepsAudio.js';
+import { generateScriptTag } from '../utils/utils.js';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'screeps-audio',

--- a/src/patches/serverStats.ts
+++ b/src/patches/serverStats.ts
@@ -1,4 +1,4 @@
-import { applyPatch, MultiPatch } from './helpers';
+import { applyPatch, MultiPatch } from './helpers.js';
 
 const patch: MultiPatch = {
     id: 'server-stats',

--- a/src/patches/stripAws.ts
+++ b/src/patches/stripAws.ts
@@ -35,20 +35,6 @@ const patch: MultiPatch = {
                 return src;
             },
         },
-        {
-            match: (url: string) => url === 'vendor/renderer/renderer.js',
-            async apply(src: string) {
-                // Modify renderer to remove AWS host from loadElement()
-                src = applyPatch(
-                    src,
-                    /\(this\.data\.src=this\.url\)/g,
-                    `(this.data.src=this.url.replace("${AWS_HOST}",""))`,
-                );
-                // Remove AWS host from image URLs
-                src = applyPatch(src, /src=t,/g, `src=t.replace("${AWS_HOST}",""),`);
-                return src;
-            },
-        },
     ],
 };
 

--- a/src/patches/stripAws.ts
+++ b/src/patches/stripAws.ts
@@ -1,7 +1,7 @@
-import { generateScriptTag } from 'utils/utils';
-import { AWS_HOST, Server } from '../utils/server';
-import { applyPatch, MultiPatch } from './helpers';
-import { roomDecorations } from 'inject/roomDecorations';
+import { generateScriptTag } from '../utils/utils.js';
+import { AWS_HOST, Server } from '../utils/server.js';
+import { applyPatch, MultiPatch } from './helpers.js';
+import { roomDecorations } from '../inject/roomDecorations.js';
 
 const patch: MultiPatch = {
     id: 'strip-aws',

--- a/src/patches/terrainTilesProfileView.ts
+++ b/src/patches/terrainTilesProfileView.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'terrain-tiles-profile-view',

--- a/src/patches/versionUpdate.ts
+++ b/src/patches/versionUpdate.ts
@@ -1,4 +1,4 @@
-import { applyPatch, Patch } from './helpers';
+import { applyPatch, Patch } from './helpers.js';
 
 const patch: Patch = {
     id: 'update-native-client',

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { ServerResponse } from 'http';
 import type { Socket } from 'net';
-import { ServerError } from './types';
+import { ServerError } from './types.js';
 
 const errorCodes: Record<PropertyKey, string> = {
     EADDRINUSE: 'The port is already in use by another application.',

--- a/src/utils/gamePath.ts
+++ b/src/utils/gamePath.ts
@@ -2,7 +2,7 @@ import Registry from 'winreg';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { logError } from './errors';
+import { logError } from './errors.js';
 
 /**
  * Get the path to the Screeps game files.

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -1,3 +1,5 @@
+import { URL } from 'url';
+
 export const AWS_HOST = 'https://s3.amazonaws.com';
 export interface ServerOptions {
     /** Whether to include the host in the final URL  */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,9 @@
 import { existsSync, promises as fs } from 'fs';
 import fetch from 'node-fetch';
 import path from 'path';
-import { Server, Route } from './server';
-import { ServerInfo } from './types';
+import { Server, Route } from './server.js';
+import { ServerInfo } from './types.js';
+import { URL } from 'url';
 
 export const mimeTypes = {
     '.css': 'text/css',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "outDir": "dist",
     "rootDir": "src",
     "allowSyntheticDefaultImports": true,
@@ -9,9 +8,9 @@
       "esnext",
       "dom"
     ],
-    "module": "ESNext",
-    "target": "ESNext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "target": "esnext",
+    "moduleResolution": "node16",
     "noImplicitOverride": true,
     "sourceMap": false,
     "strict": true,


### PR DESCRIPTION
This:
- bumps Typescript to just released v6
- remove now unnecessary patches (the forum is no more, and I think the AWS stuff was fully moved out of the renderer)
- disable the new Reddit pixel tracking
- fix some pixi.js problems with use smuggling URL parts in paths, which would make `://` turn into `:/`. AFAICT, this only affected custom player badges?