### PR TITLE
Fix some package issues

### DIFF
--- a/src/clientApp.ts
+++ b/src/clientApp.ts
@@ -153,12 +153,12 @@ const proxy = httpProxy.createProxyServer({ changeOrigin: true });
 proxy.on('error', (err, _req, res) => handleProxyError(err, res, argv.debug));
 const awsProxy = createProxyMiddleware({ target: AWS_HOST, changeOrigin: true });
 
+const pkgPath = argv.package ?? (await getScreepsPath());
+
 // Locate and read `package.nw`
 const readPackageData = async () => {
-    const pkgPath = argv.package ?? (await getScreepsPath());
     try {
         if (pkgPath) {
-            console.log('📦', chalk.dim('Package', arrow), chalk.gray(pkgPath));
             return Promise.all([fs.readFile(pkgPath), fs.stat(pkgPath)]);
         }
     } catch {
@@ -176,6 +176,26 @@ const [data, stat] = await readPackageData();
 // Read package zip metadata
 const zip = new JSZip();
 await zip.loadAsync(new Uint8Array(data));
+
+let pkg;
+try {
+    const clientPackage = (await zip.file('package.json')?.async('text')) ?? '{}';
+    pkg = JSON.parse(clientPackage);
+} catch {
+    //
+}
+
+// Ping the official server to check the deployed version
+const req = await fetch('https://screeps.com/api/version');
+const res = await req.json();
+
+console.log(
+    '📦',
+    chalk.dim('Package', arrow),
+    chalk.gray(pkgPath),
+    chalk.gray(`v${pkg.packageVersion}`),
+    res.package !== pkg.packageVersion ? chalk.red(`v${res.package} available!`) : chalk.green('Up to date'),
+);
 
 // HTTP header is only accurate to the minute
 const lastModified = stat.mtime;

--- a/src/utils/gamePath.ts
+++ b/src/utils/gamePath.ts
@@ -14,7 +14,11 @@ export async function getScreepsPath() {
         case 'darwin': {
             // MacOS, checks for screeps in the default Steam location
             const steamPath = path.join(os.homedir(), 'Library', 'Application Support', 'Steam');
-            return getScreepsPackagePath(steamPath);
+            const pkgPath = getScreepsPackagePath(steamPath);
+            if (pkgPath) {
+                return pkgPath;
+            }
+            break;
         }
 
         case 'linux': {
@@ -29,7 +33,6 @@ export async function getScreepsPath() {
                         return screepsPath;
                     }
                 }
-                return null;
             }
 
             // Linux, checks for screeps in common Steam locations within the user's home directory
@@ -46,7 +49,7 @@ export async function getScreepsPath() {
                     return screepsPath;
                 }
             }
-            return null;
+            break;
         }
 
         case 'win32': {
@@ -63,12 +66,21 @@ export async function getScreepsPath() {
             const programFilesPath =
                 env['PROGRAMFILES(X86)'] || path.join(env.SystemDrive || 'C:', 'Program Files (x86)');
             steamPath = path.join(programFilesPath, 'Steam');
-            return getScreepsPackagePath(steamPath);
+            const pkgPath = getScreepsPackagePath(steamPath);
+            if (pkgPath) {
+                return pkgPath;
+            }
+            break;
         }
+
+        default:
+            logError(`Unsupported operating system '${platform}'.`);
+            process.exit(1);
+            break;
     }
 
-    logError(`Unsupported operating system '${platform}'.`);
-    return null;
+    logError(`Unable to locate Screeps package`);
+    process.exit(1);
 }
 
 /**


### PR DESCRIPTION
The logic sometimes returns a `null` which leads to a fallthrough and early exit without reporting why.

Also added a version check against the server to report whether the local client is up to date or not.