### PR TITLE
fix: quote the CSS url() of the world map tiles

### DIFF
--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -15,6 +15,7 @@ import normalizeStringPosix from './normalizeStringPosix.js';
 import placeSpawnDefaultOff from './placeSpawnDefaultOff.js';
 import portalInfo from './portalInfo.js';
 import quietConsole from './quietConsole.js';
+import quoteMapUrl from './quoteMapUrl.js';
 import removeTracking from './removeTracking.js';
 import serverStats from './serverStats.js';
 import screepsAudio from './screepsAudio.js';
@@ -32,6 +33,7 @@ const patches: AnyPatch[] = [
     customMenuLinks,
     removeTracking,
     terrainTilesProfileView,
+    quoteMapUrl,
     placeSpawnDefaultOff,
     portalInfo,
     fixAlphaMapBounds,

--- a/src/patches/quoteMapUrl.ts
+++ b/src/patches/quoteMapUrl.ts
@@ -1,0 +1,25 @@
+import { applyPatch, Patch } from './helpers.js';
+
+const patch: Patch = {
+    id: 'quote-map-url',
+    description: 'Quote the CSS url() of the world map tiles so the (backend) path survives the CSS parser',
+    match: (url: string) => url === 'components/game/world-map/world-map.html',
+    async apply(src: string) {
+        // The three `map-sector` templates build their tile background as an unquoted `url(...)`:
+        //   'background-image': 'url('+WorldMap.mapUrl.base+sector.name+'.png?'+WorldMap.mapUrl.query+')'
+        // `fix-config` rewrites the CDN base to our proxy form `/(https://backend)/assets/map/…`, and an
+        // unquoted url-token can't hold parentheses — it ends at the first `)`, so the CSS parser drops the
+        // whole declaration. No background, no request, no error. Quoting the url fixes it.
+        //
+        // This only bites servers that report the `official-like` feature (xxscreeps), since `fix-config`
+        // rewrites the official branch of the client's mapUrl ternary; the private server branch builds its
+        // url from `options.host`/`options.port` and never contains parentheses.
+        //
+        // Angular's expression lexer understands `\'` escapes, so the quotes go in as escaped literals.
+        src = applyPatch(src, /'url\('\+/g, "'url(\\''+");
+        src = applyPatch(src, /\+'\)'/g, "+'\\')'");
+        return src;
+    },
+};
+
+export default patch;


### PR DESCRIPTION
The world map templates build their tile background as an unquoted CSS url():

    'background-image': 'url('+WorldMap.mapUrl.base+sector.name+'.png?'+...

`fix-config` rewrites the CDN base to our proxy form `/(https://backend)/assets/map/…`. An unquoted url-token cannot contain parentheses — it terminates at the first `)` — so the CSS parser discards the whole declaration. The result is a blank map with no requests and no console errors.

This only affects servers reporting the `official-like` feature (**xxscreeps**), since `fix-config` rewrites the official branch of the client's mapUrl ternary. Vanilla private servers take the other branch, which builds its url from `options.host`/`options.port` and never contains parentheses.

Quoting the url in all three zoom templates fixes it; Angular's expression lexer understands the `\'` escapes.